### PR TITLE
Update GHA permissions for Jira workflows

### DIFF
--- a/.github/workflows/jira-comment.yml
+++ b/.github/workflows/jira-comment.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   comment-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows stopped working for Jira integration, this may be the problem