### PR TITLE
Add the built-in regexp_replace function in java/scala

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -2355,6 +2355,38 @@ public final class Functions {
   }
 
   /**
+   * Returns the subject with the specified pattern (or all occurrences of the pattern) removed. If
+   * no matches are found, returns the original subject.
+   *
+   * @param strExpr The input string
+   * @param pattern The pattern
+   * @return The result column
+   * @since 1.9.0
+   */
+  public static Column regexp_replace(Column strExpr, Column pattern) {
+    return new Column(
+            com.snowflake.snowpark.functions.regexp_replace(
+                    strExpr.toScalaColumn(), pattern.toScalaColumn()));
+  }
+
+  /**
+   * Returns the subject with the specified pattern (or all occurrences of the pattern) either
+   * removed or replaced by a replacement string. If no matches are found, returns the original
+   * subject.
+   *
+   * @param strExpr The input string
+   * @param pattern The pattern
+   * @param replacement The replacement string
+   * @return The result column
+   * @since 1.9.0
+   */
+  public static Column regexp_replace(Column strExpr, Column pattern, Column replacement) {
+    return new Column(
+            com.snowflake.snowpark.functions.regexp_replace(
+                    strExpr.toScalaColumn(), pattern.toScalaColumn(), replacement.toScalaColumn()));
+  }
+
+  /**
    * Removes all occurrences of a specified strExpr, and optionally replaces them with replacement.
    *
    * @since 0.11.0

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -1797,6 +1797,27 @@ object functions {
     builtin("regexp_count")(strExpr, pattern)
 
   /**
+    * Returns the subject with the specified pattern (or all occurrences of the pattern) removed.
+    * If no matches are found, returns the original subject.
+    *
+    * @group str_func
+    * @since 1.9.0
+    */
+  def regexp_replace(strExpr: Column, pattern: Column): Column =
+    builtin("regexp_replace")(strExpr, pattern)
+
+  /**
+    * Returns the subject with the specified pattern (or all occurrences of the pattern) either
+    * removed or replaced by a replacement string. If no matches are found,
+    * returns the original subject.
+    *
+    * @group str_func
+    * @since 1.9.0
+    */
+  def regexp_replace(strExpr: Column, pattern: Column, replacement: Column): Column =
+    builtin("regexp_replace")(strExpr, pattern, replacement)
+
+  /**
    * Removes all occurrences of a specified strExpr,
    * and optionally replaces them with replacement.
    *

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -1448,6 +1448,19 @@ public class JavaFunctionSuite extends TestBase {
   }
 
   @Test
+  public void regexp_replace() {
+    DataFrame df = getSession().sql("select * from values('cat'),('dog'),('mouse') as T(a)");
+    Column pattern = Functions.lit("^ca|^[m|d]o");
+    Row[] expected = {Row.create("t"), Row.create("g"), Row.create("use")};
+    checkAnswer(df.select(Functions.regexp_replace(df.col("a"), pattern)), expected, false);
+
+    Column replacement = Functions.lit("ch");
+    Row[] expected1 = {Row.create("cht"), Row.create("chg"), Row.create("chuse")};
+    checkAnswer(
+            df.select(Functions.regexp_replace(df.col("a"), pattern, replacement)), expected1, false);
+  }
+
+  @Test
   public void replace() {
     DataFrame df = getSession().sql("select * from values('apple'),('banana'),('peach') as T(a)");
     Row[] expected = {Row.create("zpple"), Row.create("bznznz"), Row.create("pezch")};


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-897574: Add built-in function regexp_replace#46](https://github.com/snowflakedb/snowpark-java-scala/issues/46)

2. Fill out the following pre-review checklist:

   - [:white_check_mark: :  ] I am adding a new automated test(s) to verify correctness of my new code
   - [:x:  ] I am adding new logging messages
   - [:x:  ] I am adding a new telemetry message
   - [:x:  ] I am adding new credentials
   - [:x:  ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Added the builtin function `regexp_replace` in and scala and java code base.

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
