### PR TITLE
Added Array and Map literals for the java scala codebase

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -79,7 +79,7 @@ public final class Functions {
    * @return The result column
    */
   public static Column lit(Object literal) {
-    return new Column(com.snowflake.snowpark.functions.lit(literal));
+    return new Column(com.snowflake.snowpark.functions.lit(JavaUtils.toScala(literal)));
   }
 
   /**

--- a/src/main/scala/com/snowflake/snowpark/internal/JavaUtils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/JavaUtils.scala
@@ -414,21 +414,15 @@ object JavaUtils {
     }
   }
 
-  def toScala(x: Any): Any = {
+  def toScala(element: Any): Any = {
     import collection.JavaConverters._
-    x match {
-      case y: java.util.Map[_, _] =>
-        mapAsScalaMap(y).map {
-          case (d, v) => toScala(d) -> toScala(v)
-        }.toMap
-      case y: java.lang.Iterable[_] =>
-        iterableAsScalaIterable(y).toList.map {
-          item: Any => toScala(item)
-        }
-      case y: java.util.Iterator[_] =>
-        toScala(y)
-      case _ =>
-        x
+    element match {
+      case map: java.util.Map[_, _] => mapAsScalaMap(map).map {
+        case (k, v) => toScala(k) -> toScala(v)
+      }.toMap
+      case iterable: java.lang.Iterable[_] => iterableAsScalaIterable(iterable).map(toScala)
+      case iterator: java.util.Iterator[_] => asScalaIterator(iterator).map(toScala)
+      case _ => element
     }
   }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/JavaUtils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/JavaUtils.scala
@@ -414,4 +414,21 @@ object JavaUtils {
     }
   }
 
+  def toScala(x: Any): Any = {
+    import collection.JavaConverters._
+    x match {
+      case y: java.util.Map[_, _] =>
+        mapAsScalaMap(y).map {
+          case (d, v) => toScala(d) -> toScala(v)
+        }.toMap
+      case y: java.lang.Iterable[_] =>
+        iterableAsScalaIterable(y).toList.map {
+          item: Any => toScala(item)
+        }
+      case y: java.util.Iterator[_] =>
+        toScala(y)
+      case _ =>
+        x
+    }
+  }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/Literal.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/Literal.scala
@@ -2,11 +2,10 @@ package com.snowflake.snowpark.internal.analyzer
 
 import com.snowflake.snowpark.internal.ErrorMessage
 import com.snowflake.snowpark.types._
+
 import java.math.{BigDecimal => JavaBigDecimal}
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate}
-
-import scala.math.BigDecimal
 
 private[snowpark] object Literal {
   // Snowflake max precision for decimal is 38
@@ -16,7 +15,7 @@ private[snowpark] object Literal {
     decimal.round(bigDecimalRoundContext)
   }
 
-  def apply(v: Any): Literal = v match {
+  def apply(v: Any): TLiteral = v match {
     case i: Int => Literal(i, Option(IntegerType))
     case l: Long => Literal(l, Option(LongType))
     case d: Double => Literal(d, Option(DoubleType))
@@ -36,7 +35,8 @@ private[snowpark] object Literal {
     case t: Timestamp => Literal(DateTimeUtils.javaTimestampToMicros(t), Option(TimestampType))
     case ld: LocalDate => Literal(DateTimeUtils.localDateToDays(ld), Option(DateType))
     case d: Date => Literal(DateTimeUtils.javaDateToDays(d), Option(DateType))
-    case a: Array[Byte] => Literal(a, Option(BinaryType))
+    case s: Seq[Any] => ArrayLiteral(s)
+    case m: Map[Any, Any] => MapLiteral(m)
     case null => Literal(null, None)
     case v: Literal => v
     case _ =>
@@ -45,10 +45,48 @@ private[snowpark] object Literal {
 
 }
 
-private[snowpark] case class Literal private (value: Any, dataTypeOption: Option[DataType])
-    extends Expression {
+private[snowpark] trait TLiteral extends Expression {
+  def value: Any
+  def dataTypeOption: Option[DataType]
+
   override def children: Seq[Expression] = Seq.empty
 
   override protected def createAnalyzedExpression(analyzedChildren: Seq[Expression]): Expression =
     this
+}
+
+private[snowpark] case class Literal (value: Any, dataTypeOption: Option[DataType]) extends TLiteral
+
+private[snowpark] case class ArrayLiteral(value: Seq[Any]) extends TLiteral {
+  val elementsLiterals: Seq[TLiteral] = value.map(Literal(_))
+  val dataTypeOption = inferArrayType
+  
+  private[analyzer] def inferArrayType(): Option[DataType] = {
+    elementsLiterals.flatMap(_.dataTypeOption).distinct match {
+      case Seq() => None
+      case Seq(ByteType) => Some(BinaryType)
+      case Seq(dt) => Some(ArrayType(dt))
+      case Seq(_, _*) => Some(ArrayType(VariantType))
+    }
+  }
+}
+
+private[snowpark] case class MapLiteral(value: Map[Any, Any]) extends TLiteral {
+  val entriesLiterals = value.map { case (k, v) => Literal(k) -> Literal(v) }
+  val dataTypeOption = inferMapType
+  
+  private[analyzer] def inferMapType(): Option[MapType] = {
+    entriesLiterals.keys.flatMap(_.dataTypeOption).toSeq.distinct match {
+      case Seq() => None
+      case Seq(StringType) =>
+        val valuesTypes = entriesLiterals.values.flatMap(_.dataTypeOption).toSeq.distinct
+        valuesTypes match {
+          case Seq() => None
+          case Seq(dt) => Some(MapType(StringType, dt))
+          case Seq(_, _*) => Some(MapType(StringType, VariantType))
+        }
+      case _ =>
+        throw ErrorMessage.PLAN_CANNOT_CREATE_LITERAL(value.getClass.getCanonicalName, s"$value")
+    }
+  }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/SqlGenerator.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/SqlGenerator.scala
@@ -203,8 +203,8 @@ private object SqlGenerator extends Logging {
       case UnspecifiedFrame => ""
       case SpecialFrameBoundaryExtractor(str) => str
 
-      case Literal(value, dataType) =>
-        DataTypeMapper.toSql(value, dataType)
+      case l: TLiteral =>
+        DataTypeMapper.toSql(l)
       case attr: Attribute => quoteName(attr.name)
       // unresolved expression
       case UnresolvedAttribute(name) => name

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark.internal
 import com.snowflake.snowpark.FileOperationCommand._
 import com.snowflake.snowpark.Row
 import com.snowflake.snowpark.internal.Utils.{TempObjectType, randomNameForTempObject}
-import com.snowflake.snowpark.types.{DataType, convertToSFType}
+import com.snowflake.snowpark.types.{ArrayType, DataType, MapType, convertToSFType}
 
 package object analyzer {
   // constant string
@@ -446,7 +446,9 @@ package object analyzer {
     val types = output.map(_.dataType)
     val rows = data.map { row =>
       val cells = row.toSeq.zip(types).map {
-        case (v, dType) => DataTypeMapper.toSql(v, Option(dType))
+        case (v: Seq[Any], _: ArrayType) => DataTypeMapper.toSql(ArrayLiteral(v))
+        case (v: Map[Any, Any], _: MapType) => DataTypeMapper.toSql(MapLiteral(v))
+        case (v, dType) => DataTypeMapper.toSql(Literal(v, Option(dType)))
       }
       cells.mkString(_LeftParenthesis, _Comma, _RightParenthesis)
     }

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -89,15 +89,6 @@ public class JavaFunctionSuite extends TestBase {
     
     assertEquals(expectedMaps, actualMaps);
   }
-  
-  @Test
-  public void values() {
-    // Values with complex nested types
-    DataFrame df = getSession().sql("select * from values ([1, 2, 3], {\'1\': 1}, \'abc\') as T(a)");
-    Row[] rows = df.collect();
-    
-    int a = 1 + 2;
-  }
 
   @Test
   public void sqlText() {


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SNOW-899560: Support Array and Map type as java/scala Literal #47](https://github.com/snowflakedb/snowpark-java-scala/issues/47)

2. Fill out the following pre-review checklist:

   - [:white_check_mark:  ] I am adding a new automated test(s) to verify correctness of my new code
   - [:x:  ] I am adding new logging messages
   - [:x:  ] I am adding a new telemetry message
   - [:x:  ] I am adding new credentials
   - [:x:  ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Added a trait `TLiteral` with 3 children:
1. `ArrayLiteral`: Represents an array literal
2. `MapLiteral`: Represents a map literal
3. `Literal`: Represents everything else.

The Array and Map Literal holds list of literals corresponding to their elements. Those lists are used to generate the SQL for those types recursively.

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
