### PR TITLE
SCT-7633 Adding com.snowflake.snowpark.Session.SessionBuilder.getOrCreate

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -78,6 +78,9 @@ public class SessionBuilder {
    * @since 1.10.0
    */
   public Session getOrCreate() {
+    // disable closure cleaner in Java session,
+    // it only works with Scala UDF.
+    this.builder.config("snowpark_enable_closure_cleaner", "never");
     return new Session(this.builder.getOrCreate());
   }
 }

--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -78,9 +78,6 @@ public class SessionBuilder {
    * @since 1.10.0
    */
   public Session getOrCreate() {
-    // disable closure cleaner in Java session,
-    // it only works with Scala UDF.
-    this.builder.config("snowpark_enable_closure_cleaner", "never");
     return new Session(this.builder.getOrCreate());
   }
 }

--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -70,4 +70,14 @@ public class SessionBuilder {
     this.builder.config("snowpark_enable_closure_cleaner", "never");
     return new Session(builder.create());
   }
+
+  /**
+   * Returns the existing session if already exists or create it if not.
+   *
+   * @return A {@code Session} object
+   * @since 1.10.0
+   */
+  public Session getOrCreate() {
+    return new Session(this.builder.getOrCreate());
+  }
 }

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1455,6 +1455,16 @@ object Session extends Logging {
       createInternal(None)
     }
 
+    /**
+     * Returns the existing session if already exists or create it if not.
+     *
+     * @return A [[Session]]
+     * @since 1.10.0
+     */
+    def getOrCreate: Session = {
+      Session.getActiveSession.getOrElse(create)
+    }
+
     private[snowpark] def createInternal(conn: Option[SnowflakeConnectionV1]): Session = {
       conn match {
         case Some(_) =>

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
@@ -82,6 +82,14 @@ public class JavaSessionSuite extends TestBase {
   }
 
   @Test
+  public void getOrCreate()
+  {
+    String expectedSession = getSession().getSessionInfo();
+    String actualSession = Session.builder().getOrCreate().getSessionInfo();
+    assert(expectedSession.equals(actualSession));
+  }
+
+  @Test
   public void getSessionInfo() {
     String result = getSession().getSessionInfo();
     assert result.contains("snowpark.version");

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
@@ -84,9 +84,9 @@ public class JavaSessionSuite extends TestBase {
   @Test
   public void getOrCreate()
   {
-    String expectedSession = getSession().getSessionInfo();
-    String actualSession = Session.builder().getOrCreate().getSessionInfo();
-    assert(expectedSession.equals(actualSession));
+    String expectedSessionInfo = getSession().getSessionInfo();
+    String actualSessionInfo = Session.builder().getOrCreate().getSessionInfo();
+    assert(actualSessionInfo.equals(expectedSessionInfo));
   }
 
   @Test

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -49,6 +49,11 @@ class SessionSuite extends SNTestBase {
     t2.run()
   }
 
+  test("Test for get or create session") {
+    val actualSession = Session.builder.getOrCreate
+    assert(actualSession == session)
+  }
+
   test("Test for invalid configs") {
     val badSessionBuilder = Session.builder
       .configFile(defaultProfile)

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -50,8 +50,9 @@ class SessionSuite extends SNTestBase {
   }
 
   test("Test for get or create session") {
-    val actualSession = Session.builder.getOrCreate
-    assert(actualSession == session)
+    val session1 = Session.builder.getOrCreate
+    val session2 = Session.builder.getOrCreate
+    assert(session1 == session2)
   }
 
   test("Test for invalid configs") {


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes: [SCT-7633](https://snowflakecomputing.atlassian.net/browse/SCT-7633)
   
2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [X] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency
   
3. Please describe how your code solves the related issue.

   I just added com.snowflake.snowpark.Session.SessionBuilder.GetOrCreate method for both Scala and Java API to automize getOrCreate method conversion.
   
## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))

[SCT-7633]: https://snowflakecomputing.atlassian.net/browse/SCT-7633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ