### PR TITLE
SCT-7635 Create a wrapper for the is_null function.

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Column.java
+++ b/src/main/java/com/snowflake/snowpark_java/Column.java
@@ -237,6 +237,16 @@ public class Column {
   }
 
   /**
+   * Wrapper for is_null function.
+   *
+   * @return The result column object
+   * @since 1.10.0
+   */
+  public Column isNull() {
+    return is_null();
+  }
+
+  /**
    * Is not null.
    *
    * @return The result column object

--- a/src/main/scala/com/snowflake/snowpark/Column.scala
+++ b/src/main/scala/com/snowflake/snowpark/Column.scala
@@ -391,6 +391,14 @@ case class Column private[snowpark] (private[snowpark] val expr: Expression) ext
   def is_null: Column = withExpr(IsNull(expr))
 
   /**
+   * Wrapper for is_null function.
+   *
+   * @group op
+   * @since 1.10.0
+   */
+  def isNull: Column = is_null
+
+  /**
    * Is not null.
    * @group op
    * @since 0.1.0

--- a/src/test/java/com/snowflake/snowpark_test/JavaColumnSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaColumnSuite.java
@@ -117,6 +117,7 @@ public class JavaColumnSuite extends TestBase {
     DataFrame data = getSession().sql("select * from values(1),(null) as T(a)");
     Row[] expected = {Row.create(false, true), Row.create(true, false)};
     checkAnswer(data.select(data.col("a").is_null(), data.col("a").is_not_null()), expected, false);
+    checkAnswer(data.select(data.col("a").isNull(), data.col("a").is_not_null()), expected, false);
   }
 
   @Test

--- a/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
@@ -123,6 +123,7 @@ class ColumnSuite extends TestData {
 
     assert(df.where(df("A").equal_nan).collect() sameElements Array[Row](Row(Double.NaN, 3)))
     assert(df.where(df("A").is_null).collect() sameElements Array[Row](Row(null, 2)))
+    assert(df.where(df("A").isNull).collect() sameElements Array[Row](Row(null, 2)))
     assert(
       df.where(df("A").is_not_null).collect() sameElements Array[Row](
         Row(1.1, 1),


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes: [SCT-7635](https://snowflakecomputing.atlassian.net/browse/SCT-7635)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   In ApacheSpark the function is called isNull because in Scala the snake_case notation is not the standard one. By generating this wrapper both sides are going to have the same name(SparkApache and Snowpark API)

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))


[SCT-7635]: https://snowflakecomputing.atlassian.net/browse/SCT-7635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ