### PR TITLE
SCT-2668 Add appName method to SessionBuilder to register in query_tag.

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -87,7 +87,7 @@ public class SessionBuilder {
    *
    * @param appName Name of the app.
    * @return A {@code SessionBuilder} object
-   * @since 1.11.0
+   * @since 1.12.0
    */
   public SessionBuilder appName(String appName) {
     this.builder.appName(appName);

--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -82,7 +82,8 @@ public class SessionBuilder {
   }
 
   /**
-   * Adds the app name to set in the query_tag after session creation
+   * Adds the app name to set in the query_tag after session creation.
+   * The query tag will be set with this format 'APPNAME=${appName}'.
    *
    * @param appName Name of the app.
    * @return A {@code SessionBuilder} object

--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -80,4 +80,16 @@ public class SessionBuilder {
   public Session getOrCreate() {
     return new Session(this.builder.getOrCreate());
   }
+
+  /**
+   * Adds the app name to set in the query_tag after session creation
+   *
+   * @param appName Name of the app.
+   * @return A {@code Session} object
+   * @since 1.11.0
+   */
+  public SessionBuilder appName(String appName) {
+    this.builder.appName(appName);
+    return this;
+  }
 }

--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -85,7 +85,7 @@ public class SessionBuilder {
    * Adds the app name to set in the query_tag after session creation
    *
    * @param appName Name of the app.
-   * @return A {@code Session} object
+   * @return A {@code SessionBuilder} object
    * @since 1.11.0
    */
   public SessionBuilder appName(String appName) {

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1483,7 +1483,7 @@ object Session extends Logging {
     def create: Session = {
       val session = createInternal(None)
       val appName = this.appName
-      if(appName.isDefined) {
+      if (appName.isDefined) {
         session.setQueryTag(s"APPNAME=${appName.get}")
       }
       session

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1415,7 +1415,7 @@ object Session extends Logging {
      *
      * @param appName Name of the app.
      * @return A [[SessionBuilder]]
-     * @since 1.11.0
+     * @since 1.12.0
      */
     def appName(appName: String): SessionBuilder = {
       this.appName = Some(appName)

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1410,7 +1410,8 @@ object Session extends Logging {
 
 
     /**
-     * Adds the app name to set in the query_tag after session creation
+     * Adds the app name to set in the query_tag after session creation.
+     * The query tag will be set with this format 'APPNAME=${appName}'.
      *
      * @param appName Name of the app.
      * @return A [[SessionBuilder]]

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1394,6 +1394,7 @@ object Session extends Logging {
     private var options: Map[String, String] = Map()
 
     private var isScalaAPI: Boolean = true
+    private var appName: Option[String] = None
 
     // used by Java API only
     private[snowpark] def setJavaAPI(): SessionBuilder = {
@@ -1404,6 +1405,19 @@ object Session extends Logging {
     // Used only for tests
     private[snowpark] def removeConfig(key: String): SessionBuilder = {
       options -= key
+      this
+    }
+
+
+    /**
+     * Adds the app name to set in the query_tag after session creation
+     *
+     * @param appName Name of the app.
+     * @return A [[SessionBuilder]]
+     * @since 1.11.0
+     */
+    def appName(appName: String): SessionBuilder = {
+      this.appName = Some(appName)
       this
     }
 
@@ -1467,7 +1481,12 @@ object Session extends Logging {
      * @since 0.1.0
      */
     def create: Session = {
-      createInternal(None)
+      val session = createInternal(None)
+      val appName = this.appName
+      if(appName.isDefined) {
+        session.setQueryTag(s"APPNAME=${appName.get}")
+      }
+      session
     }
 
     /**

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
@@ -89,6 +89,14 @@ public class JavaSessionSuite extends TestBase {
   }
 
   @Test
+  public void appName() {
+    String appName = "my-app";
+    String expectedAppName = String.format("APPNAME=%s", appName);
+    Session session = Session.builder().configFile(defaultProfile).appName(appName).create();
+    assert (expectedAppName.equals(session.getQueryTag().get()));
+  }
+
+  @Test
   public void getSessionInfo() {
     String result = getSession().getSessionInfo();
     assert result.contains("snowpark.version");

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -251,6 +251,18 @@ class SessionSuite extends SNTestBase {
 
   }
 
+  test("Set an app name in the query tag") {
+    val appName = "my_app"
+    val expectedAppName = s"APPNAME=$appName"
+    val newSession = Session.builder.appName(appName).configFile(defaultProfile).create
+    assert(getParameterValue("query_tag", newSession) == expectedAppName)
+  }
+
+  test("The app name is not defined") {
+    val newSession = Session.builder.configFile(defaultProfile).create
+    assert(getParameterValue("query_tag", newSession) == "")
+  }
+
   test("generator") {
     checkAnswer(
       session.generator(3, Seq(lit(1).as("a"), lit(2).as("b"))),


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   This PR is intend to make easier to track Spark migrated workloads.

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It assigns the query_tag with the app name after a new session is created.

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
