### PR TITLE
SCT-10981 Add an overload method for functions.max, functions.min and functions.mean

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -267,6 +267,34 @@ public final class Functions {
    * Returns the maximum value for the records in a group. NULL values are ignored unless all the
    * records are NULL, in which case a NULL value is returned.
    *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * var df = session.createDataFrame(
+   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   *         StructType.create(new StructField("x", DataTypes.IntegerType))
+   * );
+   * df.select(max("x")).show();
+   *
+   * ----------------
+   * |"MAX(""X"")"  |
+   * ----------------
+   * |10            |
+   * ----------------
+   * }</pre>
+   *
+   * @param colName The name of the column
+   * @return The maximum value of the given column
+   * @since 1.13.0
+   */
+  public static Column max(String colName) {
+    return new Column(com.snowflake.snowpark.functions.max(colName));
+  }
+
+  /**
+   * Returns the maximum value for the records in a group. NULL values are ignored unless all the
+   * records are NULL, in which case a NULL value is returned.
+   *
    * @since 0.9.0
    * @param col The input column
    * @return The result column
@@ -279,12 +307,68 @@ public final class Functions {
    * Returns the minimum value for the records in a group. NULL values are ignored unless all the
    * records are NULL, in which case a NULL value is returned.
    *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * var df = session.createDataFrame(
+   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   *         StructType.create(new StructField("x", DataTypes.IntegerType))
+   * );
+   * df.select(min("x")).show();
+   *
+   * ----------------
+   * |"MIN(""X"")"  |
+   * ----------------
+   * |1             |
+   * ----------------
+   * }</pre>
+   *
+   * @param colName The name of the column
+   * @return The minimum value of the given column
+   * @since 1.13.0
+   */
+  public static Column min(String colName) {
+    return new Column(com.snowflake.snowpark.functions.min(colName));
+  }
+
+  /**
+   * Returns the minimum value for the records in a group. NULL values are ignored unless all the
+   * records are NULL, in which case a NULL value is returned.
+   *
    * @since 0.9.0
    * @param col The input column
    * @return The result column
    */
   public static Column min(Column col) {
     return new Column(com.snowflake.snowpark.functions.min(col.toScalaColumn()));
+  }
+
+  /**
+   * Returns the average of non-NULL records. If all records inside a group are NULL, the function
+   * returns NULL. Alias of avg.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * var df = session.createDataFrame(
+   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   *         StructType.create(new StructField("x", DataTypes.IntegerType))
+   * );
+   * df.select(mean("x")).show();
+   *
+   * ----------------
+   * |"AVG(""X"")"  |
+   * ----------------
+   * |3.600000      |
+   * ----------------
+   * }</pre>
+   *
+   * @param colName The name of the column
+   * @return The average value of the given column
+   * @since 1.13.0
+   */
+  public static Column mean(String colName) {
+    return new Column(com.snowflake.snowpark.functions.mean(colName));
   }
 
   /**

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -270,8 +270,8 @@ public final class Functions {
    * <p>Example:
    *
    * <pre>{@code
-   * var df = session.createDataFrame(
-   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   * DataFrame df = session.createDataFrame(
+   *         new Row[] {Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3)},
    *         StructType.create(new StructField("x", DataTypes.IntegerType))
    * );
    * df.select(max("x")).show();
@@ -310,8 +310,8 @@ public final class Functions {
    * <p>Example:
    *
    * <pre>{@code
-   * var df = session.createDataFrame(
-   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   * DataFrame df = session.createDataFrame(
+   *         new Row[] {Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3)},
    *         StructType.create(new StructField("x", DataTypes.IntegerType))
    * );
    * df.select(min("x")).show();
@@ -350,8 +350,8 @@ public final class Functions {
    * <p>Example:
    *
    * <pre>{@code
-   * var df = session.createDataFrame(
-   *         new Row[] { Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3) },
+   * DataFrame df = session.createDataFrame(
+   *         new Row[] {Row.create(1), Row.create(3), Row.create(10), Row.create(1), Row.create(3)},
    *         StructType.create(new StructField("x", DataTypes.IntegerType))
    * );
    * df.select(mean("x")).show();

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -269,6 +269,29 @@ object functions {
    * Returns the maximum value for the records in a group. NULL values are ignored unless all
    * the records are NULL, in which case a NULL value is returned.
    *
+   * Example:
+   * {{{
+   *   val df = session.createDataFrame(Seq(1, 3, 10, 1, 3)).toDF("x")
+   *   df.select(max("x")).show()
+   *
+   *   ----------------
+   *   |"MAX(""X"")"  |
+   *   ----------------
+   *   |10            |
+   *   ----------------
+   * }}}
+   *
+   * @param colName The name of the column
+   * @return The maximum value of the given column
+   * @group agg_func
+   * @since 1.13.0
+   */
+  def max(colName: String): Column = max(col(colName))
+
+  /**
+   * Returns the maximum value for the records in a group. NULL values are ignored unless all
+   * the records are NULL, in which case a NULL value is returned.
+   *
    * @group agg_func
    * @since 0.1.0
    */
@@ -281,6 +304,29 @@ object functions {
    * @since 0.12.0
    */
   def any_value(e: Column): Column = builtin("any_value")(e)
+
+  /**
+   * Returns the average of non-NULL records. If all records inside a group are NULL,
+   * the function returns NULL. Alias of avg.
+   *
+   * Example:
+   * {{{
+   *   val df = session.createDataFrame(Seq(1, 3, 10, 1, 3)).toDF("x")
+   *   df.select(mean("x")).show()
+   *
+   *   ----------------
+   *   |"AVG(""X"")"  |
+   *   ----------------
+   *   |3.600000      |
+   *   ----------------
+   * }}}
+   *
+   * @param colName The name of the column
+   * @return The average value of the given column
+   * @group agg_func
+   * @since 1.13.0
+   */
+  def mean(colName: String): Column = mean(col(colName))
 
   /**
    * Returns the average of non-NULL records. If all records inside a group are NULL,
@@ -301,6 +347,29 @@ object functions {
   def median(e: Column): Column = {
     builtin("median")(e)
   }
+
+  /**
+   * Returns the minimum value for the records in a group. NULL values are ignored unless all
+   * the records are NULL, in which case a NULL value is returned.
+   *
+   * Example:
+   * {{{
+   *   val df = session.createDataFrame(Seq(1, 3, 10, 1, 3)).toDF("x")
+   *   df.select(min("x")).show()
+   *
+   *   ----------------
+   *   |"MIN(""X"")"  |
+   *   ----------------
+   *   |1             |
+   *   ----------------
+   * }}}
+   *
+   * @param colName The name of the column
+   * @return The minimum value of the given column
+   * @group agg_func
+   * @since 1.13.0
+   */
+  def min(colName: String): Column = min(col(colName))
 
   /**
    * Returns the minimum value for the records in a group. NULL values are ignored unless all

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -144,10 +144,10 @@ public class JavaFunctionSuite extends TestBase {
   @Test
   public void max_min_mean() {
     // Case 01: Non-null values
-    var df1 =
+    DataFrame df1 =
         getSession()
             .sql("select * from values(1,2,1),(1,2,3),(2,1,10),(2,2,1),(2,2,3) as T(x,y,z)");
-    var expected1 = new Row[] {Row.create(2, 1, 3.600000)};
+    Row[] expected1 = {Row.create(2, 1, 3.600000)};
 
     checkAnswer(
         df1.select(
@@ -158,10 +158,10 @@ public class JavaFunctionSuite extends TestBase {
         df1.select(Functions.max("x"), Functions.min("y"), Functions.mean("z")), expected1, false);
 
     // Case 02: Some null values
-    var df2 =
+    DataFrame df2 =
         getSession()
             .sql("select * from values(1,5,8),(null,8,7),(3,null,9),(4,6,null) as T(x,y,z)");
-    var expected2 = new Row[] {Row.create(4, 5, 8.000000)};
+    Row[] expected2 = {Row.create(4, 5, 8.000000)};
 
     checkAnswer(
         df2.select(
@@ -172,11 +172,11 @@ public class JavaFunctionSuite extends TestBase {
         df2.select(Functions.max("x"), Functions.min("y"), Functions.mean("z")), expected2, false);
 
     // Case 03: All null values
-    var df3 =
+    DataFrame df3 =
         getSession()
             .sql(
                 "select * from values(null,null,null),(null,null,null),(null,null,null) as T(x,y,z)");
-    var expected3 = new Row[] {Row.create(null, null, null)};
+    Row[] expected3 = {Row.create(null, null, null)};
 
     checkAnswer(
         df3.select(

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -143,16 +143,48 @@ public class JavaFunctionSuite extends TestBase {
 
   @Test
   public void max_min_mean() {
-    DataFrame df =
+    // Case 01: Non-null values
+    var df1 =
         getSession()
             .sql("select * from values(1,2,1),(1,2,3),(2,1,10),(2,2,1),(2,2,3) as T(x,y,z)");
-    Row[] expected = {Row.create(2, 1, 3.600000)};
+    var expected1 = new Row[] {Row.create(2, 1, 3.600000)};
 
     checkAnswer(
-        df.select(
-            Functions.max(df.col("x")), Functions.min(df.col("y")), Functions.mean(df.col("z"))),
-        expected,
+        df1.select(
+            Functions.max(df1.col("x")), Functions.min(df1.col("y")), Functions.mean(df1.col("z"))),
+        expected1,
         false);
+    checkAnswer(
+        df1.select(Functions.max("x"), Functions.min("y"), Functions.mean("z")), expected1, false);
+
+    // Case 02: Some null values
+    var df2 =
+        getSession()
+            .sql("select * from values(1,5,8),(null,8,7),(3,null,9),(4,6,null) as T(x,y,z)");
+    var expected2 = new Row[] {Row.create(4, 5, 8.000000)};
+
+    checkAnswer(
+        df2.select(
+            Functions.max(df2.col("x")), Functions.min(df2.col("y")), Functions.mean(df2.col("z"))),
+        expected2,
+        false);
+    checkAnswer(
+        df2.select(Functions.max("x"), Functions.min("y"), Functions.mean("z")), expected2, false);
+
+    // Case 03: All null values
+    var df3 =
+        getSession()
+            .sql(
+                "select * from values(null,null,null),(null,null,null),(null,null,null) as T(x,y,z)");
+    var expected3 = new Row[] {Row.create(null, null, null)};
+
+    checkAnswer(
+        df3.select(
+            Functions.max(df3.col("x")), Functions.min(df3.col("y")), Functions.mean(df3.col("z"))),
+        expected3,
+        false);
+    checkAnswer(
+        df3.select(Functions.max("x"), Functions.min("y"), Functions.mean("z")), expected3, false);
   }
 
   @Test

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -76,9 +76,20 @@ trait FunctionSuite extends TestData {
   }
 
   test("max, min, mean") {
-    checkAnswer(
-      xyz.select(max(col("X")), min(col("Y")), mean(col("Z"))),
-      Seq(Row(2, 1, 3.600000)))
+    // Case 01: Non-null values
+    val expected1 = Seq(Row(2, 1, 3.600000))
+    checkAnswer(xyz.select(max(col("X")), min(col("Y")), mean(col("Z"))), expected1)
+    checkAnswer(xyz.select(max("X"), min("Y"), mean("Z")), expected1)
+
+    // Case 02: Some null values
+    val expected2 = Seq(Row(3, 1, 2.000000))
+    checkAnswer(nullInts.select(max(col("A")), min(col("A")), mean(col("A"))), expected2)
+    checkAnswer(nullInts.select(max("A"), min("A"), mean("A")), expected2)
+
+    // Case 03: All null values
+    val expected3 = Seq(Row(null, null, null))
+    checkAnswer(allNulls.select(max(col("A")), min(col("A")), mean(col("A"))), expected3)
+    checkAnswer(allNulls.select(max("A"), min("A"), mean("A")), expected3)
   }
 
   test("skew") {


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SCT-10981](https://snowflakecomputing.atlassian.net/browse/SCT-10981)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It adds an overload method that receives a column name as parameter for the following functions:
   - `com.snowflake.snowpark.functions.max`
   - `com.snowflake.snowpark.functions.min`
   - `com.snowflake.snowpark.functions.mean`

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))


[SCT-10981]: https://snowflakecomputing.atlassian.net/browse/SCT-10981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ