### PR TITLE
SNOW-1338064 Make tests not rely on ordering of results

### DIFF
--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameAggregateSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameAggregateSuite.scala
@@ -842,8 +842,9 @@ class DataFrameAggregateSuite extends TestData {
     checkAnswer(
       df.groupBy(df.col("color"))
         .agg(listagg(df.col("length"), ",")
-          .withinGroup(df.col("length").asc)),
-      Seq(Row("orange", "12"), Row("red", "21,24,35"), Row("green", "11,77"), Row("blue", "14")),
+          .withinGroup(df.col("length").asc))
+        .sort($"color"),
+      Seq(Row("blue", "14"), Row("green", "11,77"), Row("orange", "12"), Row("red", "21,24,35")),
       sort = false)
   }
 }


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes SNOW-1338064

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   This test changed in this PR rely on implicit ordering. This PR adds explicit ordering to this test by sorting the output.

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
    - I have manually run this test.
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
