### PR TITLE
SNOW-1348487 Fix Test Failure of SessionSuite in Sproc

### DIFF
--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
@@ -113,4 +113,12 @@ public class JavaSessionNonStoredProcSuite extends TestBase {
     }
     assert hasError;
   }
+
+  @Test
+  public void appName() {
+    String appName = "my-app";
+    String expectedAppName = String.format("APPNAME=%s", appName);
+    Session session = Session.builder().configFile(defaultProfile).appName(appName).create();
+    assert (expectedAppName.equals(session.getQueryTag().get()));
+  }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
@@ -89,14 +89,6 @@ public class JavaSessionSuite extends TestBase {
   }
 
   @Test
-  public void appName() {
-    String appName = "my-app";
-    String expectedAppName = String.format("APPNAME=%s", appName);
-    Session session = Session.builder().configFile(defaultProfile).appName(appName).create();
-    assert (expectedAppName.equals(session.getQueryTag().get()));
-  }
-
-  @Test
   public void getSessionInfo() {
     String result = getSession().getSessionInfo();
     assert result.contains("snowpark.version");


### PR DESCRIPTION
Test `appName` can't be executed from Sproc because it accesses the local file system.
Moved it to `JavaSessionNonStoredProcSuite`, which will be not executed in the Sproc tests.