### PR TITLE
SIT-1627: Set the app name in the session query tag in JSON format

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
+++ b/src/main/java/com/snowflake/snowpark_java/SessionBuilder.java
@@ -82,8 +82,21 @@ public class SessionBuilder {
   }
 
   /**
-   * Adds the app name to set in the query_tag after session creation. The query tag will be set
-   * with this format 'APPNAME=${appName}'.
+   * Adds the app name to set in the query_tag after session creation.
+   *
+   * <p>Since version 1.13.0, the app name is set to the query tag in JSON format. For example:
+   * <pre>{@code
+   * Session session = Session.builder().appName("myApp").configFile(myConfigFile).create();
+   * System.out.println(session.getQueryTag().get());
+   * {"APPNAME":"myApp"}
+   * }</pre>
+   *
+   * <p>In previous versions it is set using a key=value format. For example:
+   * <pre>{@code
+   * Session session = Session.builder().appName("myApp").configFile(myConfigFile).create();
+   * System.out.println(session.getQueryTag().get());
+   * APPNAME=myApp
+   * }</pre>
    *
    * @param appName Name of the app.
    * @return A {@code SessionBuilder} object

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -1502,7 +1502,20 @@ object Session extends Logging {
 
     /**
      * Adds the app name to set in the query_tag after session creation.
-     * The query tag will be set with this format 'APPNAME=${appName}'.
+     *
+     * Since version 1.13.0, the app name is set to the query tag in JSON format. For example:
+     * {{{
+     *   val session = Session.builder.appName("myApp").configFile(myConfigFile).create
+     *   print(session.getQueryTag().get)
+     *   {"APPNAME":"myApp"}
+     * }}}
+     *
+     * In previous versions it is set using a key=value format. For example:
+     * {{{
+     *   val session = Session.builder.appName("myApp").configFile(myConfigFile).create
+     *   print(session.getQueryTag().get)
+     *   APPNAME=myApp
+     * }}}
      *
      * @param appName Name of the app.
      * @return A [[SessionBuilder]]
@@ -1576,7 +1589,8 @@ object Session extends Logging {
       val session = createInternal(None)
       val appName = this.appName
       if (appName.isDefined) {
-        session.setQueryTag(s"APPNAME=${appName.get}")
+        val appNameTag = s"""{"APPNAME":"${appName.get}"}"""
+        session.updateQueryTag(appNameTag)
       }
       session
     }

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
@@ -197,7 +197,7 @@ public class JavaSessionNonStoredProcSuite extends TestBase {
   @Test
   public void appName() {
     String appName = "my-app";
-    String expectedAppName = String.format("APPNAME=%s", appName);
+    String expectedAppName = String.format("{\"APPNAME\":\"%s\"}", appName);
     Session session = Session.builder().configFile(defaultProfile).appName(appName).create();
     assert (expectedAppName.equals(session.getQueryTag().get()));
   }

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -322,7 +322,7 @@ class SessionSuite extends SNTestBase {
 
   test("Set an app name in the query tag") {
     val appName = "my_app"
-    val expectedAppName = s"APPNAME=$appName"
+    val expectedAppName = s"""{"APPNAME":"$appName"}"""
     val newSession = Session.builder.appName(appName).configFile(defaultProfile).create
     assert(getParameterValue("query_tag", newSession) == expectedAppName)
   }


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes [SIT-1627](https://snowflakecomputing.atlassian.net/browse/SIT-1627)

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   When a new session is created, the app name will be set to the session query tag in JSON format instead of the key=value format used in previous versions. The goal of this change is to make the app name compatible with the `updateQueryTag` function.

## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))


[SIT-1627]: https://snowflakecomputing.atlassian.net/browse/SIT-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ