### PR TITLE
Snow 802269 add log10, log1p, base64 and unbase64 functions

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -4054,6 +4054,90 @@ public final class Functions {
   }
 
   /**
+   * Computes the logarithm of the given value in base 10.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values (100) as T(a)");
+   * df.select(Functions.log10(df.col("a")).as("log10")).show();
+   * -----------
+   * |"LOG10"  |
+   * -----------
+   * |2.0      |
+   * -----------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param col The input column to get last value
+   * @return column object from last function.
+   */
+  public static Column log10(Column col) {
+    return new Column(functions.log10(col.toScalaColumn()));
+  }
+
+  /**
+   * Computes the logarithm of the given value in base 10.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values (100) as T(a)");
+   * df.select(Functions.log10("a").as("log10")).show();
+   * -----------
+   * |"LOG10"  |
+   * -----------
+   * |2.0      |
+   * -----------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param s The input column to get last value
+   * @return column object from last function.
+   */
+  public static Column log10(String s) {
+    return new Column(functions.log10(s));
+  }
+
+  /**
+   * Computes the logarithm of the given value in base 10.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values (0.1) as T(a)");
+   * df.select(Functions.log1p(df.col("a")).as("log1p")).show();
+   * -----------------------
+   * |"LOG1P"              |
+   * -----------------------
+   * |0.09531017980432493  |
+   * -----------------------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param col The input column to get last value
+   * @return column object from last function.
+   */
+  public static Column log1p(Column col) {
+    return new Column(functions.log1p(col.toScalaColumn()));
+  }
+
+  /**
+   * Computes the logarithm of the given value in base 10.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values (0.1) as T(a)");
+   * df.select(Functions.log1p("a").as("log1p")).show();
+   * -----------------------
+   * |"LOG1P"              |
+   * -----------------------
+   * |0.09531017980432493  |
+   * -----------------------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param s The input column to get last value
+   * @return column object from last function.
+   */
+  public static Column log1p(String s) {
+    return new Column(functions.log1p(s));
+  }
+
+  /**
    * Calls a user-defined function (UDF) by name.
    *
    * @since 0.12.0

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -4138,6 +4138,49 @@ public final class Functions {
   }
 
   /**
+   * Computes the BASE64 encoding of a column and returns it as a string column. This is the reverse
+   * of unbase64.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values ('test') as T(a)");
+   * df.select(Functions.base64(Functions.col("a")).as("base64")).show();
+   * ------------
+   * |"BASE64"  |
+   * ------------
+   * |dGVzdA==  |
+   * ------------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param c ColumnName to apply base64 operation
+   * @return base64 encoded value of the given input column.
+   */
+  public static Column base64(Column c) {
+    return new Column(functions.base64(c.toScalaColumn()));
+  }
+
+  /**
+   * Decodes a BASE64 encoded string column and returns it as a column.
+   *
+   * <pre>{@code
+   * DataFrame df = getSession().sql("select * from values ('dGVzdA==') as T(a)");
+   * df.select(Functions.unbase64(Functions.col("a")).as("unbase64")).show();
+   * --------------
+   * |"UNBASE64"  |
+   * --------------
+   * |test        |
+   * --------------
+   * }</pre>
+   *
+   * @since 1.14.0
+   * @param c ColumnName to apply unbase64 operation
+   * @return the decoded value of the given encoded value.
+   */
+  public static Column unbase64(Column c) {
+    return new Column(functions.unbase64(c.toScalaColumn()));
+  }
+
+  /**
    * Calls a user-defined function (UDF) by name.
    *
    * @since 0.12.0

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -4067,8 +4067,8 @@ public final class Functions {
    * }</pre>
    *
    * @since 1.14.0
-   * @param col The input column to get last value
-   * @return column object from last function.
+   * @param col The input column to get logarithm value
+   * @return column object from logarithm function.
    */
   public static Column log10(Column col) {
     return new Column(functions.log10(col.toScalaColumn()));
@@ -4088,8 +4088,8 @@ public final class Functions {
    * }</pre>
    *
    * @since 1.14.0
-   * @param s The input column to get last value
-   * @return column object from last function.
+   * @param s The input columnName in string to get logarithm value
+   * @return column object from logarithm function.
    */
   public static Column log10(String s) {
     return new Column(functions.log10(s));
@@ -4109,8 +4109,8 @@ public final class Functions {
    * }</pre>
    *
    * @since 1.14.0
-   * @param col The input column to get last value
-   * @return column object from last function.
+   * @param col The input column to get logarithm value
+   * @return column object from logarithm function.
    */
   public static Column log1p(Column col) {
     return new Column(functions.log1p(col.toScalaColumn()));
@@ -4130,8 +4130,8 @@ public final class Functions {
    * }</pre>
    *
    * @since 1.14.0
-   * @param s The input column to get last value
-   * @return column object from last function.
+   * @param s The input columnName in string to get logarithm value
+   * @return column object from logarithm function.
    */
   public static Column log1p(String s) {
     return new Column(functions.log1p(s));

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -3357,7 +3357,7 @@ object functions {
    *Example
    * {{{
    *  val df = session.createDataFrame(Seq(0.1)).toDF("a")
-   *  df.select(log1p(col("a"))).show()
+   *  df.select(log1p(col("a")).as("log1p")).show()
    * -----------------------
    * |"LOG1P"              |
    * -----------------------

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -3347,7 +3347,7 @@ object functions {
    * }}}
    *
    * @since 1.14.0
-   * @param columnName Column to apply logarithm operation
+   * @param columnName ColumnName in String to apply logarithm operation
    * @return log10 of the given column
    */
   def log10(columnName: String): Column = builtin("LOG")(10, col(columnName))
@@ -3387,7 +3387,7 @@ object functions {
    * }}}
    *
    * @since 1.14.0
-   * @param columnName Column to apply logarithm operation
+   * @param columnName ColumnName in String to apply logarithm operation
    * @return the natural logarithm of the given value plus one.
    */
   def log1p(columnName: String): Column = callBuiltin("ln", lit(1) + col(columnName))

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -3354,16 +3354,40 @@ object functions {
 
   /**
    * Computes the natural logarithm of the given value plus one.
+   *Example
+   * {{{
+   *  val df = session.createDataFrame(Seq(0.1)).toDF("a")
+   *  df.select(log1p(col("a"))).show()
+   * -----------------------
+   * |"LOG1P"              |
+   * -----------------------
+   * |0.09531017980432493  |
+   * -----------------------
+   *
+   * }}}
+   *
    * @since 1.14.0
-   * @param c the value to use
+   * @param c Column to apply logarithm operation
    * @return the natural logarithm of the given value plus one.
    */
   def log1p(c: Column): Column = callBuiltin("ln", lit(1) + c)
 
   /**
    * Computes the natural logarithm of the given value plus one.
+   *Example
+   * {{{
+   *  val df = session.createDataFrame(Seq(0.1)).toDF("a")
+   *  df.select(log1p("a").as("log1p")).show()
+   * -----------------------
+   * |"LOG1P"              |
+   * -----------------------
+   * |0.09531017980432493  |
+   * -----------------------
+   *
+   * }}}
+   *
    * @since 1.14.0
-   * @param columnName the value to use
+   * @param columnName Column to apply logarithm operation
    * @return the natural logarithm of the given value plus one.
    */
   def log1p(columnName: String): Column = callBuiltin("ln", lit(1) + col(columnName))

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -3393,6 +3393,47 @@ object functions {
   def log1p(columnName: String): Column = callBuiltin("ln", lit(1) + col(columnName))
 
   /**
+   * Computes the BASE64 encoding of a column and returns it as a string column.
+   * This is the reverse of unbase64.
+   *Example
+   * {{{
+   *  val df = session.createDataFrame(Seq("test")).toDF("a")
+   *  df.select(base64(col("a")).as("base64")).show()
+   * ------------
+   * |"BASE64"  |
+   * ------------
+   * |dGVzdA==  |
+   * ------------
+   *
+   * }}}
+   *
+   * @since 1.14.0
+   * @param columnName ColumnName to apply base64 operation
+   * @return base64 encoded value of the given input column.
+   */
+  def base64(col: Column): Column = callBuiltin("BASE64_ENCODE", col)
+
+  /**
+   * Decodes a BASE64 encoded string column and returns it as a column.
+   *Example
+   * {{{
+   *  val df = session.createDataFrame(Seq("dGVzdA==")).toDF("a")
+   *  df.select(unbase64(col("a")).as("unbase64")).show()
+   * --------------
+   * |"UNBASE64"  |
+   * --------------
+   * |test        |
+   * --------------
+   *
+   * }}}
+   *
+   * @since 1.14.0
+   * @param columnName ColumnName to apply unbase64 operation
+   * @return the decoded value of the given encoded value.
+   */
+  def unbase64(col: Column): Column = callBuiltin("BASE64_DECODE_STRING", col)
+
+  /**
    * Invokes a built-in snowflake function with the specified name and arguments.
    * Arguments can be of two types
    *

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -3313,6 +3313,62 @@ object functions {
     builtin("LAST_VALUE")(c)
 
   /**
+   * Computes the logarithm of the given value in base 10.
+   * Example
+   * {{{
+   *  val df = session.createDataFrame(Seq(100)).toDF("a")
+   *  df.select(log10(col("a"))).show()
+   *
+   * -----------
+   * |"LOG10"  |
+   * -----------
+   * |2.0      |
+   * -----------
+   * }}}
+   *
+   * @since 1.14.0
+   * @param c Column to apply logarithm operation
+   * @return log10 of the given column
+   */
+  def log10(c: Column): Column = builtin("LOG")(10, c)
+
+  /**
+   * Computes the logarithm of the given column in base 10.
+   * Example
+   * {{{
+   *  val df = session.createDataFrame(Seq(100)).toDF("a")
+   *  df.select(log10("a"))).show()
+   * -----------
+   * |"LOG10"  |
+   * -----------
+   * |2.0      |
+   * -----------
+   *
+   * }}}
+   *
+   * @since 1.14.0
+   * @param columnName Column to apply logarithm operation
+   * @return log10 of the given column
+   */
+  def log10(columnName: String): Column = builtin("LOG")(10, col(columnName))
+
+  /**
+   * Computes the natural logarithm of the given value plus one.
+   * @since 1.14.0
+   * @param c the value to use
+   * @return the natural logarithm of the given value plus one.
+   */
+  def log1p(c: Column): Column = callBuiltin("ln", lit(1) + c)
+
+  /**
+   * Computes the natural logarithm of the given value plus one.
+   * @since 1.14.0
+   * @param columnName the value to use
+   * @return the natural logarithm of the given value plus one.
+   */
+  def log1p(columnName: String): Column = callBuiltin("ln", lit(1) + col(columnName))
+
+  /**
    * Invokes a built-in snowflake function with the specified name and arguments.
    * Arguments can be of two types
    *

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -2828,4 +2828,36 @@ public class JavaFunctionSuite extends TestBase {
         expected,
         false);
   }
+
+  @Test
+  public void log10_col() {
+    DataFrame df = getSession().sql("select * from values (100) as T(a)");
+    Row[] expected = {Row.create(2.0)};
+
+    checkAnswer(df.select(Functions.log10(df.col("a"))), expected, false);
+  }
+
+  @Test
+  public void log10_str() {
+    DataFrame df = getSession().sql("select * from values (100) as T(a)");
+    Row[] expected = {Row.create(2.0)};
+
+    checkAnswer(df.select(Functions.log10("a")), expected, false);
+  }
+
+  @Test
+  public void log1p_col() {
+    DataFrame df = getSession().sql("select * from values (0.1) as T(a)");
+    Row[] expected = {Row.create(0.09531017980432493)};
+
+    checkAnswer(df.select(Functions.log1p(df.col("a"))), expected, false);
+  }
+
+  @Test
+  public void log1p_str() {
+    DataFrame df = getSession().sql("select * from values (0.1) as T(a)");
+    Row[] expected = {Row.create(0.09531017980432493)};
+
+    checkAnswer(df.select(Functions.log1p("a")), expected, false);
+  }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -2860,4 +2860,18 @@ public class JavaFunctionSuite extends TestBase {
 
     checkAnswer(df.select(Functions.log1p("a")), expected, false);
   }
+
+  @Test
+  public void base64() {
+    DataFrame df = getSession().sql("select * from values ('test') as T(a)");
+    Row[] expected = {Row.create("dGVzdA==")};
+    checkAnswer(df.select(Functions.base64(Functions.col("a"))), expected, false);
+  }
+
+  @Test
+  public void unbase64() {
+    DataFrame df = getSession().sql("select * from values ('dGVzdA==') as T(a)");
+    Row[] expected = {Row.create("test")};
+    checkAnswer(df.select(Functions.unbase64(Functions.col("a"))), expected, false);
+  }
 }

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -2268,6 +2268,18 @@ trait FunctionSuite extends TestData {
     checkAnswer(input.select(log1p("a").as("log1p")), expected, sort = false)
   }
 
+  test("base64 function") {
+    val input = session.createDataFrame(Seq("test")).toDF("a")
+    val expected = Seq("dGVzdA==").toDF("base64")
+    checkAnswer(input.select(base64(col("a")).as("base64")), expected, sort = false)
+  }
+
+  test("unbase64 function") {
+    val input = session.createDataFrame(Seq("dGVzdA==")).toDF("a")
+    val expected = Seq("test").toDF("unbase64")
+    checkAnswer(input.select(unbase64(col("a")).as("unbase64")), expected, sort = false)
+  }
+
 }
 
 class EagerFunctionSuite extends FunctionSuite with EagerSession

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -2247,7 +2247,6 @@ trait FunctionSuite extends TestData {
   test("log10 Column function") {
     val input = session.createDataFrame(Seq(100)).toDF("a")
     val expected = Seq(2.0).toDF("log10")
-
     checkAnswer(
       input.select(log10(col("a")).as("log10")),
       expected,
@@ -2257,7 +2256,6 @@ trait FunctionSuite extends TestData {
   test("log10 String function") {
     val input = session.createDataFrame(Seq("100")).toDF("a")
     val expected = Seq(2.0).toDF("log10")
-
     checkAnswer(
       input.select(log10("a").as("log10")),
       expected,
@@ -2265,26 +2263,22 @@ trait FunctionSuite extends TestData {
   }
 
   test("log1p Column function") {
-    val input = session.createDataFrame(Seq(100)).toDF("a")
-
-    input.select(log1p(col("a"))).show()
-//    val expected = Seq(2.0).toDF("log10")
-//
-//    checkAnswer(
-//      input.select(log10(col("a")).as("log10")),
-//      expected,
-//      sort = false)
+    val input = session.createDataFrame(Seq(0.1)).toDF("a")
+    val expected = Seq(0.09531017980432493).toDF("log1p")
+    checkAnswer(
+      input.select(log1p(col("a")).as("log10")),
+      expected,
+      sort = false)
   }
-//
-//  test("log1p String function") {
-//    val input = session.createDataFrame(Seq("100")).toDF("a")
-//    val expected = Seq(2.0).toDF("log10")
-//
-//    checkAnswer(
-//      input.select(log10("a").as("log10")),
-//      expected,
-//      sort = false)
-//  }
+
+  test("log1p String function") {
+    val input = session.createDataFrame(Seq(0.1)).toDF("a")
+    val expected = Seq(0.09531017980432493).toDF("log1p")
+    checkAnswer(
+      input.select(log1p("a").as("log1p")),
+      expected,
+      sort = false)
+  }
 
 }
 

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -2233,7 +2233,6 @@ trait FunctionSuite extends TestData {
   }
 
   test("last function") {
-
     val input =
       Seq((5, "a", 10), (5, "b", 20), (3, "d", 15), (3, "e", 40)).toDF("grade", "name", "score")
     val window = Window.partitionBy(col("grade")).orderBy(col("score").desc)
@@ -2244,6 +2243,48 @@ trait FunctionSuite extends TestData {
       expected,
       sort = false)
   }
+
+  test("log10 Column function") {
+    val input = session.createDataFrame(Seq(100)).toDF("a")
+    val expected = Seq(2.0).toDF("log10")
+
+    checkAnswer(
+      input.select(log10(col("a")).as("log10")),
+      expected,
+      sort = false)
+  }
+
+  test("log10 String function") {
+    val input = session.createDataFrame(Seq("100")).toDF("a")
+    val expected = Seq(2.0).toDF("log10")
+
+    checkAnswer(
+      input.select(log10("a").as("log10")),
+      expected,
+      sort = false)
+  }
+
+  test("log1p Column function") {
+    val input = session.createDataFrame(Seq(100)).toDF("a")
+
+    input.select(log1p(col("a"))).show()
+//    val expected = Seq(2.0).toDF("log10")
+//
+//    checkAnswer(
+//      input.select(log10(col("a")).as("log10")),
+//      expected,
+//      sort = false)
+  }
+//
+//  test("log1p String function") {
+//    val input = session.createDataFrame(Seq("100")).toDF("a")
+//    val expected = Seq(2.0).toDF("log10")
+//
+//    checkAnswer(
+//      input.select(log10("a").as("log10")),
+//      expected,
+//      sort = false)
+//  }
 
 }
 

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -2247,37 +2247,25 @@ trait FunctionSuite extends TestData {
   test("log10 Column function") {
     val input = session.createDataFrame(Seq(100)).toDF("a")
     val expected = Seq(2.0).toDF("log10")
-    checkAnswer(
-      input.select(log10(col("a")).as("log10")),
-      expected,
-      sort = false)
+    checkAnswer(input.select(log10(col("a")).as("log10")), expected, sort = false)
   }
 
   test("log10 String function") {
     val input = session.createDataFrame(Seq("100")).toDF("a")
     val expected = Seq(2.0).toDF("log10")
-    checkAnswer(
-      input.select(log10("a").as("log10")),
-      expected,
-      sort = false)
+    checkAnswer(input.select(log10("a").as("log10")), expected, sort = false)
   }
 
   test("log1p Column function") {
     val input = session.createDataFrame(Seq(0.1)).toDF("a")
     val expected = Seq(0.09531017980432493).toDF("log1p")
-    checkAnswer(
-      input.select(log1p(col("a")).as("log10")),
-      expected,
-      sort = false)
+    checkAnswer(input.select(log1p(col("a")).as("log10")), expected, sort = false)
   }
 
   test("log1p String function") {
     val input = session.createDataFrame(Seq(0.1)).toDF("a")
     val expected = Seq(0.09531017980432493).toDF("log1p")
-    checkAnswer(
-      input.select(log1p("a").as("log1p")),
-      expected,
-      sort = false)
+    checkAnswer(input.select(log1p("a").as("log1p")), expected, sort = false)
   }
 
 }


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   Fixes #802269

2. Fill out the following pre-review checklist:

   - [X] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Add log10 and log1p functions for scala and java which takes column name as both ColumnType and StringType

| API | Description |
|--------|--------|
| function.log10 | Computes the logarithm of the given column in base 10 |
| functions.log1p | Computes the natural logarithm of the given value plus one |
| functions.base64 | Computes the BASE64 encoding of a column and returns it as a string column.|
| functions.unbase64 | Decodes a BASE64 encoded string column and returns it as a column. |

## Pre-review checklist

(For Snowflake employees)

- [X] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
