### PR TITLE
SNOW-1820719 Refactor Session.sql Function

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Session.java
+++ b/src/main/java/com/snowflake/snowpark_java/Session.java
@@ -65,7 +65,7 @@ public class Session {
    * @since 0.8.0
    */
   public DataFrame sql(String query) {
-    return new DataFrame(session.sql(query, JavaUtils.objectArrayToSeq(new Object[0])));
+    return new DataFrame(session.sql(query));
   }
 
   /**

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -945,11 +945,24 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
    * You can use this method to execute an arbitrary SQL statement.
    *
    * @param query The SQL statement to execute.
-   * @param params for bind variables in SQL statement.
    * @return A [[DataFrame]]
    * @since 0.1.0
    */
-  def sql(query: String, params: Seq[Any] = Seq.empty): DataFrame = {
+  def sql(query: String): DataFrame = {
+    sql(query, Seq.empty)
+  }
+
+  /**
+   * Returns a new DataFrame representing the results of a SQL query.
+   *
+   * You can use this method to execute an arbitrary SQL statement.
+   *
+   * @param query The SQL statement to execute.
+   * @param params for bind variables in SQL statement.
+   * @return A [[DataFrame]]
+   * @since 1.15.0
+   */
+  def sql(query: String, params: Seq[Any]): DataFrame = {
     // PUT and GET command cannot be executed in async mode
     DataFrame(this, plans.query(query, None, !Utils.isPutOrGetCommand(query), params))
   }


### PR DESCRIPTION
We found a regression in the release tests. It is a legacy issue, Java Sproc can invoke Scala session. However, when Java code invokes Scala functions, the default value of function arguments will be ignored. Therefore, the new change in the `Session.sql` will break all existing code related this function.
This PR refactor the `Session.sql` function to split it to two functions, with and without parameters. Then the new API will not impact any existing code.
