### PR TITLE
SNOW-1793953 allow GET from relative paths starting with / for native apps

### DIFF
--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -49,6 +49,8 @@ object Utils extends Logging {
   val TempObjectNamePattern: String =
     "^SNOWPARK_TEMP_(TABLE|VIEW|STAGE|FUNCTION|TABLE_FUNCTION|FILE_FORMAT|PROCEDURE)_[0-9A-Z]+$"
 
+  val SnowflakePathPrefixes: List[String] = List("@", "snow://", "/")
+
   // Temp object name generation
   val randomGenerator = new Random(System.nanoTime())
   @inline private final val _TEMP_OBJECT_PREFIX: String = "SNOWPARK_TEMP"
@@ -152,7 +154,7 @@ object Utils extends Logging {
 
   def normalizeStageLocation(name: String): String = {
     val trimName = name.trim
-    if (trimName.startsWith("@")) trimName else s"@$trimName"
+    if (SnowflakePathPrefixes.exists(trimName.startsWith(_))) trimName else s"@$trimName"
   }
 
   private def isSingleQuoted(name: String): Boolean =

--- a/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
@@ -257,6 +257,10 @@ class UtilsSuite extends SNTestBase {
     val name2 = """"DATABASE"."SCHEMA"."STAGE""""
     assert(Utils.normalizeStageLocation(" " + name2).equals(s"@$name2"))
     assert(Utils.normalizeStageLocation("@" + name2 + "  ").equals(s"@$name2"))
+    val name3 = "snow://domain/test_entity/versions/test_version/file.txt"
+    assert(Utils.normalizeStageLocation(name3).equals(name3))
+    val name4 = "/some/file.txt"
+    assert(Utils.normalizeStageLocation(name4).equals(name4))
   }
 
   test("normalizeLocalFile") {


### PR DESCRIPTION

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

  SNOW-1793953
   Fixes #183 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This allows stage paths starting with `/` and will not try to prepend `@` to them for the native apps use case. This mirrors the same change in snowpark-python ([PR](https://github.com/snowflakedb/snowpark-python/pull/2889)), and also applies the same change for `snow://` paths which is already implemented in snowpark-python ([PR](https://github.com/snowflakedb/snowpark-python/pull/1346)).



## Pre-review checklist

(For Snowflake employees)

- [ ] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))
