### PR TITLE
SNOW-2098807: Correct NotMatchedClauseBuilder Insert column mapping

### DIFF
--- a/src/main/scala/com/snowflake/snowpark/MergeClause.scala
+++ b/src/main/scala/com/snowflake/snowpark/MergeClause.scala
@@ -106,14 +106,15 @@ class NotMatchedClauseBuilder private[snowpark] (
    * @return [[MergeBuilder]]
    */
   def insert(assignments: Map[Column, Column]): MergeBuilder = {
+    val assignmentSeq = assignments.toSeq
     MergeBuilder(
       mergeBuilder.target,
       mergeBuilder.source,
       mergeBuilder.joinExpr,
       mergeBuilder.clauses :+ InsertMergeExpression(
         condition.map(_.expr),
-        assignments.toSeq.map(_._1.expr),
-        assignments.toSeq.map(_._2.expr)),
+        assignmentSeq.map(_._1.expr),
+        assignmentSeq.map(_._2.expr)),
       inserted = true,
       mergeBuilder.updated,
       mergeBuilder.deleted)

--- a/src/main/scala/com/snowflake/snowpark/MergeClause.scala
+++ b/src/main/scala/com/snowflake/snowpark/MergeClause.scala
@@ -112,8 +112,8 @@ class NotMatchedClauseBuilder private[snowpark] (
       mergeBuilder.joinExpr,
       mergeBuilder.clauses :+ InsertMergeExpression(
         condition.map(_.expr),
-        assignments.keys.toSeq.map(_.expr),
-        assignments.values.toSeq.map(_.expr)),
+        assignments.toSeq.map(_._1.expr),
+        assignments.toSeq.map(_._2.expr)),
       inserted = true,
       mergeBuilder.updated,
       mergeBuilder.deleted)


### PR DESCRIPTION
Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR addressing? Make sure that there is an accompanying issue to your PR.

   [SNOW-2098807](https://snowflakecomputing.atlassian.net/browse/SNOW-2098807)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   `assignments.keys.toSeq` produces the incorrect order of keys in the `Map`. Converting the `Map` to a sequence first maintains the order of insertion. 

## Pre-review checklist

(For Snowflake employees)

- [x] This change has passed precommit
- [ ] I have reviewed code coverage report for my PR in  ([Sonarqube](https://sonarqube.int.snowflakecomputing.com/dashboard?id=snowpark))


[SNOW-2098807]: https://snowflakecomputing.atlassian.net/browse/SNOW-2098807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ