### PR TITLE
SNOW-2273045: use quotes to actually filter out SampleDataTest

### DIFF
--- a/scripts/jenkins_fips_regress_aws.sh
+++ b/scripts/jenkins_fips_regress_aws.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_fips_regress_az.sh
+++ b/scripts/jenkins_fips_regress_az.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_fips_regress_gcp.sh
+++ b/scripts/jenkins_fips_regress_gcp.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress.sh
+++ b/scripts/jenkins_regress.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress_az.sh
+++ b/scripts/jenkins_regress_az.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress_az_latest_jdbc.sh
+++ b/scripts/jenkins_regress_az_latest_jdbc.sh
@@ -43,7 +43,7 @@ rm -fr ./src/test/scala/com/snowflake/snowpark/ReplSuite.scala
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress_gcp.sh
+++ b/scripts/jenkins_regress_gcp.sh
@@ -19,7 +19,7 @@ gpg --quiet --batch --yes --decrypt --passphrase="$GPG_KEY" --output profile.pro
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress_gcp_latest_jdbc.sh
+++ b/scripts/jenkins_regress_gcp_latest_jdbc.sh
@@ -43,7 +43,7 @@ rm -fr ./src/test/scala/com/snowflake/snowpark/ReplSuite.scala
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""

--- a/scripts/jenkins_regress_latest_jdbc.sh
+++ b/scripts/jenkins_regress_latest_jdbc.sh
@@ -43,7 +43,7 @@ rm -fr ./src/test/scala/com/snowflake/snowpark/ReplSuite.scala
 exit_code_decorator "sbt clean +compile"
 exit_code_decorator "sbt +JavaAPITests:test"
 exit_code_decorator "sbt +NonparallelTests:test"
-exit_code_decorator "sbt UDFTests:testOnly * -- -l SampleDataTest"
+exit_code_decorator "sbt \"UDFTests:testOnly * -- -l SampleDataTest\""
 exit_code_decorator "sbt \"++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest\""
 exit_code_decorator "sbt UDTFTests:test"
 exit_code_decorator "sbt \"++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest\""


### PR DESCRIPTION
SNOW-2273045

Needed to wrap the related parameters inside quotes for `sbt` to pick up on the filter flag with the `testOnly` command together.