### PR TITLE
SNOW-2282231: Update build and release scripts for Maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -257,20 +257,20 @@ lazy val root = (project in file("."))
       Properties.envOrNone("GPG_HEX_CODE").getOrElse("Jenkins_build_not_set_GPG_HEX_CODE"),
       "ignored" // this field is ignored; passwords are supplied by pinentry
     ),
-    resolvers +=
-      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     // usePgpKeyHex(Properties.envOrElse("GPG_SIGNATURE", "12345")),
     Global / pgpPassphrase := Properties.envOrNone("GPG_KEY_PASSPHRASE").map(_.toCharArray),
     publishMavenStyle := true,
     releaseCrossBuild := true,
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-    publishTo := Some(
+    // New setting for the Central Portal
+    publishTo := {
+      val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
       if (isSnapshot.value) {
-        Opts.resolver.sonatypeOssSnapshots.head
+        Some("central-snapshots" at centralSnapshots)
       } else {
-        Opts.resolver.sonatypeStaging
+        localStaging.value
       }
-    ),
+    },
     pomExtra :=
       <developers>
         <developer>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.1
+sbt.version = 1.11.4

--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -24,13 +24,13 @@ import scala.util.Random
 
 object Utils extends Logging {
   val Version: String = BuildInfo.version
-  // Package name of snowpark on server side
-  val SnowparkPackageName = "com.snowflake:snowpark"
-  val PackageNameDelimiter = ":"
   // Define the compat scala version instead of reading from property file
   // because it fails to read the property file in some environment such as
   // VSCode worksheet.
   val ScalaCompatVersion: String = BuildInfo.scalaVersion.split("\\.").take(2).mkString(".")
+  // Package name of snowpark on server side
+  val SnowparkPackageName = s"com.snowflake:snowpark_$ScalaCompatVersion"
+  val PackageNameDelimiter = ":"
 
   // Minimum GS version for us to identify as Snowpark client
   val MinimumGSVersionForSnowparkClientType: String = "5.20.0"


### PR DESCRIPTION
SNOW-2282231

Follow the example of https://github.com/snowflakedb/spark-snowflake/pull/617/files to update the `deploy.sh` script to use new Maven Central repository publishing process.

Includes additional necessary changes to `sbt` version as well as `sbt` plugin versions.

Currently publishing still requires a manual step of logging into the central repository to manually publish the artifacts after verification. This can be automated later.

Additionally, this PR changes the client package name to include the Scala version as a suffix (e.g. `snowpark_2.13`​) to follow the design for [server-side UDxF and SProc support](https://docs.google.com/document/d/1z8yfSw7Q_PHav2OQen9bZJ5iJnRB3qaAtQR73BiyN6U/edit?tab=t.0#heading=h.p8ilppt5ftg).