### PR TITLE
SNOW-2294179 Add support for `StructType.fieldNames`

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/types/StructType.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/StructType.java
@@ -71,13 +71,47 @@ public class StructType extends DataType implements Iterable<StructField> {
   }
 
   /**
-   * Retrieves the names of StructField.
+   * Retrieves the names of all {@link com.snowflake.snowpark_java.types.StructField} in this {@link
+   * com.snowflake.snowpark_java.types.StructType}.
    *
-   * @return An array of String representing the names of StructFields
+   * <p>Example:
+   *
+   * <pre>{@code
+   * StructType schema = new StructType(new StructField[] {
+   *   new StructField("c1", DataTypes.IntegerType),
+   *   new StructField("c2", DataTypes.StringType),
+   * });
+   * schema.names();
+   * // res: String[] = {"C1", "C2"}
+   * }</pre>
+   *
+   * @return an array representing the names of the fields in this StructType.
    * @since 0.9.0
    */
   public String[] names() {
     return JavaUtils.seqToJavaStringArray(this.scalaStructType.names());
+  }
+
+  /**
+   * Retrieves the names of all {@link com.snowflake.snowpark_java.types.StructField} in this {@link
+   * com.snowflake.snowpark_java.types.StructType}. This is an alias of {@link #names}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * StructType schema = new StructType(new StructField[] {
+   *   new StructField("c1", DataTypes.IntegerType),
+   *   new StructField("c2", DataTypes.StringType),
+   * });
+   * schema.fieldNames();
+   * // res: String[] = {"C1", "C2"}
+   * }</pre>
+   *
+   * @return an array representing the names of the fields in this StructType.
+   * @since 1.17.0
+   */
+  public String[] fieldNames() {
+    return this.names();
   }
 
   /**

--- a/src/main/scala/com/snowflake/snowpark/types/StructType.scala
+++ b/src/main/scala/com/snowflake/snowpark/types/StructType.scala
@@ -84,10 +84,37 @@ case class StructType(fields: Array[StructField] = Array()) extends DataType wit
     add(StructField(name, dataType, nullable))
 
   /**
-   * (Scala API Only) Returns a Seq of the name of [[StructField]].
+   * Retrieves the names of all [[StructField]] in this [[StructType]].
+   *
+   * Example:
+   * {{{
+   *   val schema = StructType(Array(StructField("c1", IntegerType), StructField("c2", StringType)))
+   *   schema.names
+   *   // res: Seq[String] = List("C1", "C2")
+   * }}}
+   *
+   * @return
+   *   a sequence representing the names of the fields in this StructType.
    * @since 0.1.0
    */
   def names: Seq[String] = fields.map(_.name)
+
+  /**
+   * Retrieves the names of all [[StructField]] in this [[StructType]]. This is an alias of
+   * [[names]].
+   *
+   * Example:
+   * {{{
+   *   val schema = StructType(Array(StructField("c1", IntegerType), StructField("c2", StringType)))
+   *   schema.fieldNames
+   *   // res: Seq[String] = List("C1", "C2")
+   * }}}
+   *
+   * @return
+   *   a sequence representing the names of the fields in this StructType.
+   * @since 1.17.0
+   */
+  def fieldNames: Seq[String] = names
 
   /**
    * Returns the corresponding [[StructField]] object of the given name.

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
@@ -2,6 +2,7 @@ package com.snowflake.snowpark_test;
 
 import com.snowflake.snowpark.internal.JavaDataTypeUtils;
 import com.snowflake.snowpark_java.types.*;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -309,6 +310,7 @@ public class JavaDataTypesSuite {
     assert names.length == 2;
     assert names[0].equals("C1");
     assert names[1].equals("C2");
+    assert Arrays.equals(type2.fieldNames(), names);
     assert type1.size() == 2;
     assert StructType.create(new StructField("c3", DataTypes.FloatType)).size() == 1;
 

--- a/src/test/scala/com/snowflake/snowpark_test/DataTypeSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataTypeSuite.scala
@@ -95,6 +95,7 @@ class DataTypeSuite extends SNTestBase {
     assert(tpe("col1") == StructField("col1", IntegerType))
 
     assert(tpe.names == Seq("COL1", "COL2"))
+    assert(tpe.fieldNames == tpe.names)
     assert(tpe.nameToField("col3").isEmpty)
 
     assertThrows[ArrayIndexOutOfBoundsException] {


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [SNOW-2294179](https://snowflakecomputing.atlassian.net/browse/SNOW-2294179)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This pull request adds a new `fieldNames` method to both the Java and Scala `StructType` classes as an alias for the existing `names` method. It also updates documentation and adds corresponding unit tests to verify the new method works as expected.

[SNOW-2294179]: https://snowflakecomputing.atlassian.net/browse/SNOW-2294179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ