### PR TITLE
SNOW-2246204 Add new overload for `DataFrame.sort`

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/DataFrame.java
+++ b/src/main/java/com/snowflake/snowpark_java/DataFrame.java
@@ -606,6 +606,53 @@ public class DataFrame extends Logging implements Cloneable {
   }
 
   /**
+   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in SQL).
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * DataFrame df = session.createDataFrame(
+   *   new Row[] {
+   *     Row.create("Alice", 30, "Manager"),
+   *     Row.create("Charlie", 25, "Designer"),
+   *     Row.create("Bob", 25, "Engineer"),
+   *   },
+   *   StructType.create(
+   *     new StructField("name", DataTypes.StringType),
+   *     new StructField("age", DataTypes.IntegerType),
+   *     new StructField("role", DataTypes.StringType)
+   *   )
+   * );
+   *
+   * df.sort("role").show();
+   * ------------------------------
+   * |"NAME"   |"AGE"  |"ROLE"    |
+   * ------------------------------
+   * |Charlie  |25     |Designer  |
+   * |Bob      |25     |Engineer  |
+   * |Alice    |30     |Manager   |
+   * ------------------------------
+   *
+   * df.sort("age", "name").show();
+   * ------------------------------
+   * |"NAME"   |"AGE"  |"ROLE"    |
+   * ------------------------------
+   * |Bob      |25     |Engineer  |
+   * |Charlie  |25     |Designer  |
+   * |Alice    |30     |Manager   |
+   * ------------------------------
+   * }</pre>
+   *
+   * @param first The first column name for sorting the DataFrame.
+   * @param remaining Additional column names for sorting the DataFrame.
+   * @return A {@code DataFrame} with rows sorted according to the specified column names.
+   * @since 1.17.0
+   */
+  public DataFrame sort(String first, String... remaining) {
+    return new DataFrame(df.sort(first, JavaUtils.stringArrayToStringSeq(remaining)));
+  }
+
+  /**
    * Returns a new DataFrame that contains at most `n` rows from the current DataFrame (similar to
    * LIMIT in SQL).
    *

--- a/src/main/java/com/snowflake/snowpark_java/DataFrame.java
+++ b/src/main/java/com/snowflake/snowpark_java/DataFrame.java
@@ -650,7 +650,7 @@ public class DataFrame extends Logging implements Cloneable {
    * @since 1.17.0
    */
   public DataFrame sort(String first, String... remaining) {
-    return new DataFrame(df.sort(first, JavaUtils.stringArrayToStringSeq(remaining)));
+    return new DataFrame(this.df.sort(first, JavaUtils.stringArrayToStringSeq(remaining)));
   }
 
   /**

--- a/src/main/java/com/snowflake/snowpark_java/DataFrame.java
+++ b/src/main/java/com/snowflake/snowpark_java/DataFrame.java
@@ -606,7 +606,8 @@ public class DataFrame extends Logging implements Cloneable {
   }
 
   /**
-   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in SQL).
+   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in
+   * SQL).
    *
    * <p>Example:
    *

--- a/src/main/scala/com/snowflake/snowpark/DataFrame.scala
+++ b/src/main/scala/com/snowflake/snowpark/DataFrame.scala
@@ -517,7 +517,7 @@ class DataFrame private[snowpark] (
    * @since 1.17.0
    */
   def sort(first: String, remaining: String*): DataFrame = transformation("sort") {
-    sort((first +: remaining).map(Column(_)))
+    this.sort((first +: remaining).map(Column(_)))
   }
 
   /**

--- a/src/main/scala/com/snowflake/snowpark/DataFrame.scala
+++ b/src/main/scala/com/snowflake/snowpark/DataFrame.scala
@@ -477,6 +477,49 @@ class DataFrame private[snowpark] (
   }
 
   /**
+   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in SQL).
+   *
+   * Example:
+   * {{{
+   *  val df = Seq(
+   *    ("Alice", 30, "Manager"),
+   *    ("Charlie", 25, "Designer"),
+   *    ("Bob", 25, "Engineer"),
+   *  ).toDF("name", "age", "role")
+   *
+   *  df.sort("role").show()
+   *  ------------------------------
+   *  |"NAME"   |"AGE"  |"ROLE"    |
+   *  ------------------------------
+   *  |Charlie  |25     |Designer  |
+   *  |Bob      |25     |Engineer  |
+   *  |Alice    |30     |Manager   |
+   *  ------------------------------
+   *
+   *  df.sort("age", "name").show()
+   *  ------------------------------
+   *  |"NAME"   |"AGE"  |"ROLE"    |
+   *  ------------------------------
+   *  |Bob      |25     |Engineer  |
+   *  |Charlie  |25     |Designer  |
+   *  |Alice    |30     |Manager   |
+   *  ------------------------------
+   * }}}
+   *
+   * @param first
+   *   The first column name for sorting the DataFrame.
+   * @param remaining
+   *   Additional column names for sorting the DataFrame.
+   * @return
+   *   A [[DataFrame]] with rows sorted according to the specified column names.
+   * @group transform
+   * @since 1.17.0
+   */
+  def sort(first: String, remaining: String*): DataFrame = transformation("sort") {
+    sort((first +: remaining).map(Column(_)))
+  }
+
+  /**
    * Sorts a DataFrame by the specified expressions (similar to ORDER BY in SQL).
    *
    * For example:

--- a/src/main/scala/com/snowflake/snowpark/DataFrame.scala
+++ b/src/main/scala/com/snowflake/snowpark/DataFrame.scala
@@ -477,7 +477,8 @@ class DataFrame private[snowpark] (
   }
 
   /**
-   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in SQL).
+   * Sorts a DataFrame by the specified column names in ascending order (similar to ORDER BY in
+   * SQL).
    *
    * Example:
    * {{{

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
@@ -374,36 +374,40 @@ public class JavaDataFrameSuite extends TestBase {
         getSession()
             .sql(
                 "select * from values"
-                    + "('Alice', 30, 'Manager'), "
-                    + "('Charlie', 25, 'Designer'), "
-                    + "('Bob', 25, 'Engineer') "
+                    + "('Alice', 25, 'Engineer'), "
+                    + "('Bob', 25, 'Designer'), "
+                    + "('Charlie', 30, 'Engineer'), "
+                    + "('Diana', 25, 'Engineer') "
                     + "as t(name, age, role)");
 
     // Sort by single column
     checkAnswer(
         df.sort("role"),
         new Row[] {
-          Row.create("Charlie", 25, "Designer"),
-          Row.create("Bob", 25, "Engineer"),
-          Row.create("Alice", 30, "Manager"),
+          Row.create("Bob", 25, "Designer"),
+          Row.create("Alice", 25, "Engineer"),
+          Row.create("Charlie", 30, "Engineer"),
+          Row.create("Diana", 25, "Engineer"),
         });
 
     // Sort by exactly two columns
     checkAnswer(
         df.sort("age", "name"),
         new Row[] {
-          Row.create("Bob", 25, "Engineer"),
-          Row.create("Charlie", 25, "Designer"),
-          Row.create("Alice", 30, "Manager"),
+          Row.create("Alice", 25, "Engineer"),
+          Row.create("Bob", 25, "Designer"),
+          Row.create("Diana", 25, "Engineer"),
+          Row.create("Charlie", 30, "Engineer"),
         });
 
     // Sort by three or more columns
     checkAnswer(
         df.sort("age", "role", "name"),
         new Row[] {
-          Row.create("Charlie", 25, "Designer"),
-          Row.create("Bob", 25, "Engineer"),
-          Row.create("Alice", 30, "Manager"),
+          Row.create("Bob", 25, "Designer"),
+          Row.create("Alice", 25, "Engineer"),
+          Row.create("Diana", 25, "Engineer"),
+          Row.create("Charlie", 30, "Engineer"),
         });
 
     // Negative test: column doesn't exist

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
@@ -805,23 +805,38 @@ trait DataFrameSuite extends TestData with BeforeAndAfterEach {
   }
 
   test("test sort(String, String*)") {
-    val df = Seq(("Alice", 30, "Manager"), ("Charlie", 25, "Designer"), ("Bob", 25, "Engineer"))
-      .toDF("name", "age", "role")
+    val df = Seq(
+      ("Alice", 25, "Engineer"),
+      ("Bob", 25, "Designer"),
+      ("Charlie", 30, "Engineer"),
+      ("Diana", 25, "Engineer")).toDF("name", "age", "role")
 
     // Sort by single column
     checkAnswer(
       df.sort("role"),
-      Seq(Row("Charlie", 25, "Designer"), Row("Bob", 25, "Engineer"), Row("Alice", 30, "Manager")))
+      Seq(
+        Row("Bob", 25, "Designer"),
+        Row("Alice", 25, "Engineer"),
+        Row("Charlie", 30, "Engineer"),
+        Row("Diana", 25, "Engineer")))
 
     // Sort by exactly two columns
     checkAnswer(
       df.sort("age", "name"),
-      Seq(Row("Bob", 25, "Engineer"), Row("Charlie", 25, "Designer"), Row("Alice", 30, "Manager")))
+      Seq(
+        Row("Alice", 25, "Engineer"),
+        Row("Bob", 25, "Designer"),
+        Row("Diana", 25, "Engineer"),
+        Row("Charlie", 30, "Engineer")))
 
     // Sort by three or more columns
     checkAnswer(
       df.sort("age", "role", "name"),
-      Seq(Row("Charlie", 25, "Designer"), Row("Bob", 25, "Engineer"), Row("Alice", 30, "Manager")))
+      Seq(
+        Row("Bob", 25, "Designer"),
+        Row("Alice", 25, "Engineer"),
+        Row("Diana", 25, "Engineer"),
+        Row("Charlie", 30, "Engineer")))
 
     // Negative test: column doesn't exist
     assertThrows[SnowflakeSQLException]({

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
@@ -804,6 +804,31 @@ trait DataFrameSuite extends TestData with BeforeAndAfterEach {
     })
   }
 
+  test("test sort(String, String*)") {
+    val df = Seq(("Alice", 30, "Manager"), ("Charlie", 25, "Designer"), ("Bob", 25, "Engineer"))
+      .toDF("name", "age", "role")
+
+    // Sort by single column
+    checkAnswer(
+      df.sort("role"),
+      Seq(Row("Charlie", 25, "Designer"), Row("Bob", 25, "Engineer"), Row("Alice", 30, "Manager")))
+
+    // Sort by exactly two columns
+    checkAnswer(
+      df.sort("age", "name"),
+      Seq(Row("Bob", 25, "Engineer"), Row("Charlie", 25, "Designer"), Row("Alice", 30, "Manager")))
+
+    // Sort by three or more columns
+    checkAnswer(
+      df.sort("age", "role", "name"),
+      Seq(Row("Charlie", 25, "Designer"), Row("Bob", 25, "Engineer"), Row("Alice", 30, "Manager")))
+
+    // Negative test: column doesn't exist
+    assertThrows[SnowflakeSQLException]({
+      df.sort("non_existent_column").collect()
+    })
+  }
+
   test("test select()") {
     val df = Seq((1, "a", 10), (2, "b", 20), (3, "c", 30)).toDF("a", "b", "c")
 


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [SNOW-2246204](https://snowflakecomputing.atlassian.net/browse/SNOW-2246204)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It adds a new overload for the `com.snowflake.snowpark.DataFrame.sort` function:
     - `sort(String, String*)`


[SNOW-2246204]: https://snowflakecomputing.atlassian.net/browse/SNOW-2246204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ