### PR TITLE
SNOW-2273045: Always set Scala version explicitly in Jenkins regress scripts

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -66,11 +66,11 @@ run_test_suites() {
   sbt clean +compile \
     +JavaAPITests:test \
     +NonparallelTests:test \
-    'UDFTests:testOnly * -- -l SampleDataTest' \
-    '++ 2.13.16 UDFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest -l SampleDataTest' \
-    UDTFTests:test \
-    '++ 2.13.16 UDTFTests:testOnly * -- -l com.snowflake.snowpark.UDFPackageTest' \
-    +SprocTests:test \
-    'OtherTests:testOnly * -- -l SampleDataTest' \
-    '++ 2.13.16 OtherTests:testOnly * -- -l SampleDataTest'
+    '++ 2.12.20 OtherTests:testOnly * -- -l SampleDataTest' \
+    '++ 2.13.16 OtherTests:testOnly * -- -l SampleDataTest' \
+    '++ 2.12.20 UDFTests:testOnly * -- -l SampleDataTest' \
+    '++ 2.13.16 UDFTests:testOnly * --  -l SampleDataTest -l com.snowflake.snowpark.UDFPackageTest' \
+    '++ 2.12.20 UDTFTests:testOnly * -- -l SampleDataTest' \
+    '++ 2.13.16 UDTFTests:testOnly * -- -l SampleDataTest -l com.snowflake.snowpark.UDFPackageTest' \
+    +SprocTests:test
 }


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

    Fixes SNOW-2273045
2. Fill out the following pre-review checklist:
    - [ ] I am adding a new automated test(s) to verify correctness of my new code
    - [ ] I am adding new logging messages
    - [ ] I am adding a new telemetry message
    - [ ] I am adding new credentials
    - [ ] I am adding a new dependency
3. Please describe how your code solves the related issue.

    `sbt` was inheriting the last set Scala version in the `run_test_suites` function in `utils.sh`. This was causing failures as `PackageUDFSuite` tests should be ignored for now in Scala 2.13. Setting the Scala version explicitly before each test command should resolve this issue for all Jenkins regress pipelines.