### PR TITLE
SNOW-2246264 Add new overloads for `functions.lpad` and `functions.rpad`

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -1546,6 +1546,65 @@ public final class Functions {
   }
 
   /**
+   * Left-pads a string with characters from another string.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * DataFrame df = session.createDataFrame(
+   *   new Row[] {Row.create("hello"), Row.create("world")},
+   *   StructType.create(new StructField("a", DataTypes.StringType))
+   * );
+   * df.select(lpad(col("a"), 10, "*")).show();
+   *
+   * --------------------------
+   * |"LPAD(""A"", 10, '*')"  |
+   * --------------------------
+   * |*****hello              |
+   * |*****world              |
+   * --------------------------
+   * }</pre>
+   *
+   * @param str The string column to pad.
+   * @param len The target length of the resulting string value (in characters).
+   * @param pad The string literal to use for padding.
+   * @return A new column containing the left-padded string.
+   * @since 1.17.0
+   */
+  public static Column lpad(Column str, int len, String pad) {
+    return new Column(com.snowflake.snowpark.functions.lpad(str.toScalaColumn(), len, pad));
+  }
+
+  /**
+   * Left-pads a binary value with bytes from another binary value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * DataFrame df = session.createDataFrame(
+   *   new Row[] {Row.create((Object) new byte[]{65, 66})},
+   *   StructType.create(new StructField("a", DataTypes.BinaryType))
+   * );
+   * df.select(lpad(col("a"), 5, new byte[] {0})).show();
+   *
+   * ------------------------------------
+   * |"LPAD(""A"", 5, '00' :: BINARY)"  |
+   * ------------------------------------
+   * |'0000004142'                      |
+   * ------------------------------------
+   * }</pre>
+   *
+   * @param str The binary column to pad.
+   * @param len The target length of the resulting binary value (in bytes).
+   * @param pad The byte array to use for padding.
+   * @return A new column containing the left-padded binary value.
+   * @since 1.17.0
+   */
+  public static Column lpad(Column str, int len, byte[] pad) {
+    return new Column(com.snowflake.snowpark.functions.lpad(str.toScalaColumn(), len, pad));
+  }
+
+  /**
    * Right-pads a string with characters from another string, or right-pads a binary value with
    * bytes from another binary value.
    *
@@ -1559,6 +1618,65 @@ public final class Functions {
     return new Column(
         com.snowflake.snowpark.functions.rpad(
             str.toScalaColumn(), len.toScalaColumn(), pad.toScalaColumn()));
+  }
+
+  /**
+   * Right-pads a string with characters from another string.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * DataFrame df = session.createDataFrame(
+   *   new Row[] {Row.create("hello"), Row.create("world")},
+   *   StructType.create(new StructField("a", DataTypes.StringType))
+   * );
+   * df.select(rpad(col("a"), 10, "*")).show();
+   *
+   * --------------------------
+   * |"RPAD(""A"", 10, '*')"  |
+   * --------------------------
+   * |hello*****              |
+   * |world*****              |
+   * --------------------------
+   * }</pre>
+   *
+   * @param str The string column to pad.
+   * @param len The target length of the resulting string value (in characters).
+   * @param pad The string literal to use for padding.
+   * @return A new column containing the right-padded string.
+   * @since 1.17.0
+   */
+  public static Column rpad(Column str, int len, String pad) {
+    return new Column(com.snowflake.snowpark.functions.rpad(str.toScalaColumn(), len, pad));
+  }
+
+  /**
+   * Right-pads a binary value with bytes from another binary value.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * DataFrame df = session.createDataFrame(
+   *   new Row[] {Row.create((Object) new byte[]{65, 66})},
+   *   StructType.create(new StructField("a", DataTypes.BinaryType))
+   * );
+   * df.select(rpad(col("a"), 5, new byte[] {0})).show();
+   *
+   * ------------------------------------
+   * |"RPAD(""A"", 5, '00' :: BINARY)"  |
+   * ------------------------------------
+   * |'4142000000'                      |
+   * ------------------------------------
+   * }</pre>
+   *
+   * @param str The binary column to pad.
+   * @param len The target length of the resulting binary value (in bytes).
+   * @param pad The byte array to use for padding.
+   * @return A new column containing the right-padded binary value.
+   * @since 1.17.0
+   */
+  public static Column rpad(Column str, int len, byte[] pad) {
+    return new Column(com.snowflake.snowpark.functions.rpad(str.toScalaColumn(), len, pad));
   }
 
   /**

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -1582,10 +1582,10 @@ public final class Functions {
    *
    * <pre>{@code
    * DataFrame df = session.createDataFrame(
-   *   new Row[] {Row.create((Object) new byte[]{65, 66})},
+   *   new Row[] {Row.create((Object) new byte[]{0x41, 0x42})},
    *   StructType.create(new StructField("a", DataTypes.BinaryType))
    * );
-   * df.select(lpad(col("a"), 5, new byte[] {0})).show();
+   * df.select(lpad(col("a"), 5, new byte[] {0x00})).show();
    *
    * ------------------------------------
    * |"LPAD(""A"", 5, '00' :: BINARY)"  |
@@ -1657,10 +1657,10 @@ public final class Functions {
    *
    * <pre>{@code
    * DataFrame df = session.createDataFrame(
-   *   new Row[] {Row.create((Object) new byte[]{65, 66})},
+   *   new Row[] {Row.create((Object) new byte[]{0x41, 0x42})},
    *   StructType.create(new StructField("a", DataTypes.BinaryType))
    * );
-   * df.select(rpad(col("a"), 5, new byte[] {0})).show();
+   * df.select(rpad(col("a"), 5, new byte[] {0x00})).show();
    *
    * ------------------------------------
    * |"RPAD(""A"", 5, '00' :: BINARY)"  |

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -1371,7 +1371,7 @@ object functions {
    * @group str_func
    * @since 1.17.0
    */
-  def lpad(str: Column, len: Int, pad: String): Column = lpad(str, lit(len), lit(pad))
+  def lpad(str: Column, len: Int, pad: String): Column = this.lpad(str, lit(len), lit(pad))
 
   /**
    * Left-pads a binary value with bytes from another binary value.
@@ -1399,7 +1399,7 @@ object functions {
    * @group str_func
    * @since 1.17.0
    */
-  def lpad(str: Column, len: Int, pad: Array[Byte]): Column = lpad(str, lit(len), lit(pad))
+  def lpad(str: Column, len: Int, pad: Array[Byte]): Column = this.lpad(str, lit(len), lit(pad))
 
   /**
    * Removes leading characters, including whitespace, from a string.
@@ -1454,7 +1454,7 @@ object functions {
    * @group str_func
    * @since 1.17.0
    */
-  def rpad(str: Column, len: Int, pad: String): Column = rpad(str, lit(len), lit(pad))
+  def rpad(str: Column, len: Int, pad: String): Column = this.rpad(str, lit(len), lit(pad))
 
   /**
    * Right-pads a binary value with bytes from another binary value.
@@ -1482,7 +1482,7 @@ object functions {
    * @group str_func
    * @since 1.17.0
    */
-  def rpad(str: Column, len: Int, pad: Array[Byte]): Column = rpad(str, lit(len), lit(pad))
+  def rpad(str: Column, len: Int, pad: Array[Byte]): Column = this.rpad(str, lit(len), lit(pad))
 
   /**
    * Builds a string by repeating the input for the specified number of times.

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -1345,6 +1345,63 @@ object functions {
     builtin("lpad")(str, len, pad)
 
   /**
+   * Left-pads a string with characters from another string.
+   *
+   * Examples:
+   * {{{
+   *   val df = Seq("hello", "world").toDF("a")
+   *   df.select(lpad(col("a"), 10, "*")).show()
+   *
+   *   --------------------------
+   *   |"LPAD(""A"", 10, '*')"  |
+   *   --------------------------
+   *   |*****hello              |
+   *   |*****world              |
+   *   --------------------------
+   * }}}
+   *
+   * @param str
+   *   The string column to pad.
+   * @param len
+   *   The target length of the resulting string value (in characters).
+   * @param pad
+   *   The string literal to use for padding.
+   * @return
+   *   A new column containing the left-padded string.
+   * @group str_func
+   * @since 1.17.0
+   */
+  def lpad(str: Column, len: Int, pad: String): Column = lpad(str, lit(len), lit(pad))
+
+  /**
+   * Left-pads a binary value with bytes from another binary value.
+   *
+   * Examples:
+   * {{{
+   *   val df = Seq(Array[Byte](65, 66)).toDF("a")
+   *   df.select(lpad(col("a"), 5, Array[Byte](0))).show()
+   *
+   *   ------------------------------------
+   *   |"LPAD(""A"", 5, '00' :: BINARY)"  |
+   *   ------------------------------------
+   *   |'0000004142'                      |
+   *   ------------------------------------
+   * }}}
+   *
+   * @param str
+   *   The binary column to pad.
+   * @param len
+   *   The target length of the resulting binary value (in bytes).
+   * @param pad
+   *   The byte array to use for padding.
+   * @return
+   *   A new column containing the left-padded binary value.
+   * @group str_func
+   * @since 1.17.0
+   */
+  def lpad(str: Column, len: Int, pad: Array[Byte]): Column = lpad(str, lit(len), lit(pad))
+
+  /**
    * Removes leading characters, including whitespace, from a string.
    *
    * @group str_func
@@ -1369,6 +1426,63 @@ object functions {
    */
   def rpad(str: Column, len: Column, pad: Column): Column =
     builtin("rpad")(str, len, pad)
+
+  /**
+   * Right-pads a string with characters from another string.
+   *
+   * Examples:
+   * {{{
+   *   val df = Seq("hello", "world").toDF("a")
+   *   df.select(rpad(col("a"), 10, "*")).show()
+   *
+   *   --------------------------
+   *   |"RPAD(""A"", 10, '*')"  |
+   *   --------------------------
+   *   |hello*****              |
+   *   |world*****              |
+   *   --------------------------
+   * }}}
+   *
+   * @param str
+   *   The string column to pad.
+   * @param len
+   *   The target length of the resulting string value (in characters).
+   * @param pad
+   *   The string literal to use for padding.
+   * @return
+   *   A new column containing the right-padded string.
+   * @group str_func
+   * @since 1.17.0
+   */
+  def rpad(str: Column, len: Int, pad: String): Column = rpad(str, lit(len), lit(pad))
+
+  /**
+   * Right-pads a binary value with bytes from another binary value.
+   *
+   * Examples:
+   * {{{
+   *   val df = Seq(Array[Byte](65, 66)).toDF("a")
+   *   df.select(rpad(col("a"), 5, Array[Byte](0))).show()
+   *
+   *   ------------------------------------
+   *   |"RPAD(""A"", 5, '00' :: BINARY)"  |
+   *   ------------------------------------
+   *   |'4142000000'                      |
+   *   ------------------------------------
+   * }}}
+   *
+   * @param str
+   *   The binary column to pad.
+   * @param len
+   *   The target length of the resulting binary value (in bytes).
+   * @param pad
+   *   The byte array to use for padding.
+   * @return
+   *   A new column containing the right-padded binary value.
+   * @group str_func
+   * @since 1.17.0
+   */
+  def rpad(str: Column, len: Int, pad: Array[Byte]): Column = rpad(str, lit(len), lit(pad))
 
   /**
    * Builds a string by repeating the input for the specified number of times.

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -1378,8 +1378,8 @@ object functions {
    *
    * Examples:
    * {{{
-   *   val df = Seq(Array[Byte](65, 66)).toDF("a")
-   *   df.select(lpad(col("a"), 5, Array[Byte](0))).show()
+   *   val df = Seq(Array[Byte](0x41, 0x42)).toDF("a")
+   *   df.select(lpad(col("a"), 5, Array[Byte](0x00))).show()
    *
    *   ------------------------------------
    *   |"LPAD(""A"", 5, '00' :: BINARY)"  |
@@ -1461,8 +1461,8 @@ object functions {
    *
    * Examples:
    * {{{
-   *   val df = Seq(Array[Byte](65, 66)).toDF("a")
-   *   df.select(rpad(col("a"), 5, Array[Byte](0))).show()
+   *   val df = Seq(Array[Byte](0x41, 0x42)).toDF("a")
+   *   df.select(rpad(col("a"), 5, Array[Byte](0x00))).show()
    *
    *   ------------------------------------
    *   |"RPAD(""A"", 5, '00' :: BINARY)"  |


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [SNOW-2246264](https://snowflakecomputing.atlassian.net/browse/SNOW-2246264)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It adds new overloads for the `com.snowflake.snowpark.functions.lpad` and `com.snowflake.snowpark.functions.rpad` functions:
   * `lpad(Column, Int, String)`
   * `lpad(Column, Int, Array[Byte])`
   * `rpad(Column, Int, String)`
   * `rpad(Column, Int, Array[Byte])`


[SNOW-2246264]: https://snowflakecomputing.atlassian.net/browse/SNOW-2246264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ