### PR TITLE
SNOW-2246194 Add support for `functions.concat_ws_ignore_nulls` and `functions.array_flatten`

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -1504,14 +1504,16 @@ public final class Functions {
    *   )
    * );
    *
-   * df.select(concat_ws_ignore_nulls(" | ", col("A"), col("B"), col("C"))).show();
-   * --------------------------------------------------------
-   * |"CONCAT_WS_IGNORE_NULLS(' | ', ""A"", ""B"", ""C"")"  |
-   * --------------------------------------------------------
-   * |Hello | World                                         |
-   * |                                                      |
-   * |Hello                                                 |
-   * --------------------------------------------------------
+   * df.select(
+   *   concat_ws_ignore_nulls(" | ", col("A"), col("B"), col("C")).as("concat_ws_ignore_nulls")
+   * ).show();
+   * ----------------------------
+   * |"CONCAT_WS_IGNORE_NULLS"  |
+   * ----------------------------
+   * |Hello | World             |
+   * |                          |
+   * |Hello                     |
+   * ----------------------------
    * }</pre>
    *
    * @param separator A string literal used as the separator between concatenated values.

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -1328,14 +1328,16 @@ object functions {
    *   )
    * )
    *
-   * df.select(concat_ws_ignore_nulls(" | ", col("A"), col("B"), col("C"))).show()
-   * --------------------------------------------------------
-   * |"CONCAT_WS_IGNORE_NULLS(' | ', ""A"", ""B"", ""C"")"  |
-   * --------------------------------------------------------
-   * |Hello | World                                         |
-   * |                                                      |
-   * |Hello                                                 |
-   * --------------------------------------------------------
+   * df.select(
+   *   concat_ws_ignore_nulls(" | ", col("A"), col("B"), col("C")).as("concat_ws_ignore_nulls")
+   * ).show()
+   * ----------------------------
+   * |"CONCAT_WS_IGNORE_NULLS"  |
+   * ----------------------------
+   * |Hello | World             |
+   * |                          |
+   * |Hello                     |
+   * ----------------------------
    * }}}
    *
    * @param separator
@@ -1350,13 +1352,7 @@ object functions {
   def concat_ws_ignore_nulls(separator: String, exprs: Column*): Column = {
     val stringArrays = exprs.map(_.cast(ArrayType(StringType)))
     val nonNullArray = array_compact(array_flatten(array_construct_compact(stringArrays: _*)))
-    val columnNames =
-      exprs.zipWithIndex
-        .map { case (col, idx) => col.getName.getOrElse(s"COL$idx") }
-        .mkString(", ")
-
     array_to_string(nonNullArray, lit(separator))
-      .alias(s"CONCAT_WS_IGNORE_NULLS('$separator', $columnNames)")
   }
 
   /**

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -894,12 +894,23 @@ public class JavaFunctionSuite extends TestBase {
                   Row.create(Date.valueOf("2021-12-21")), Row.create(Date.valueOf("1969-12-31"))
                 },
                 StructType.create(new StructField("YearMonth", DataTypes.DateType)));
+
     checkAnswer(
         df2.select(
             Functions.concat_ws_ignore_nulls(
                 "-",
                 Functions.year(Functions.col("YearMonth")),
                 Functions.month(Functions.col("YearMonth")))),
+        new Row[] {Row.create("2021-12"), Row.create("1969-12")});
+
+    // Resulting column should allow to define an alias
+    checkAnswer(
+        df2.select(
+            Functions.concat_ws_ignore_nulls(
+                    "-",
+                    Functions.year(Functions.col("YearMonth")),
+                    Functions.month(Functions.col("YearMonth")))
+                .alias("YEAR_MONTH")),
         new Row[] {Row.create("2021-12"), Row.create("1969-12")});
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -454,8 +454,16 @@ trait FunctionSuite extends TestData {
     val df2 = session.createDataFrame(
       Seq(Row(Date.valueOf("2021-12-21")), Row(Date.valueOf("1969-12-31"))),
       StructType(StructField("YearMonth", DateType)))
+
     checkAnswer(
       df2.select(concat_ws_ignore_nulls("-", year(col("YearMonth")), month(col("YearMonth")))),
+      Seq(Row("2021-12"), Row("1969-12")))
+
+    // Resulting column should allow to define an alias
+    checkAnswer(
+      df2.select(
+        concat_ws_ignore_nulls("-", year(col("YearMonth")), month(col("YearMonth")))
+          .alias("YEAR_MONTH")),
       Seq(Row("2021-12"), Row("1969-12")))
   }
 


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [SNOW-2246194](https://snowflakecomputing.atlassian.net/browse/SNOW-2246194)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   It adds two new functions in the `com.snowflake.snowpark.functions` package:
   - `concat_ws_ignore_nulls(String, Column*)`
   - `array_flatten(Column)`


[SNOW-2246194]: https://snowflakecomputing.atlassian.net/browse/SNOW-2246194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ