### PR TITLE
SNOW-2246196 | SNOW-2245985 Adding support for 'when'  and 'otherwise'  methods when Any value type

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/CaseExpr.java
+++ b/src/main/java/com/snowflake/snowpark_java/CaseExpr.java
@@ -20,25 +20,56 @@ public class CaseExpr extends Column {
   }
 
   /**
-   * Appends one more WHEN condition to the CASE expression.
+   * Appends one more WHEN condition to the CASE expression. This method handles any literal value
+   * and converts it into a `Column`.
    *
-   * @since 0.12.0
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * Column result = when(col("age").lt(lit(18)), "Minor")
+   * .when(col("age").lt(lit(65)), "Adult")
+   * .otherwise("Senior");
+   * }</pre>
+   *
    * @param condition The case condition
    * @param value The result value in the given condition
    * @return The result case expression
+   * @since 1.17.0
    */
-  public CaseExpr when(Column condition, Column value) {
-    return new CaseExpr(caseExpr.when(condition.toScalaColumn(), value.toScalaColumn()));
+  public CaseExpr when(Column condition, Object value) {
+    return new CaseExpr(caseExpr.when(condition.toScalaColumn(), toExpr(value).toScalaColumn()));
   }
 
   /**
-   * Sets the default result for this CASE expression.
+   * Sets the default result for this CASE expression. This method handles any literal value and
+   * converts it into a `Column`.
    *
-   * @since 0.12.0
-   * @param value The default value
-   * @return The result column
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
+   * Column result = when(col("state").equal(lit("CA")), lit(1000))
+   * .when(col("state").equal(lit("NY")), lit(2000))
+   * .otherwise(1000);
+   * }</pre>
+   *
+   * @param value The default value, which can be any literal (e.g., String, int, boolean) or a
+   *     `Column`.
+   * @return The result column.
+   * @since 1.17.0
    */
-  public Column otherwise(Column value) {
-    return new Column(caseExpr.otherwise(value.toScalaColumn()));
+  public Column otherwise(Object value) {
+    return new Column(caseExpr.otherwise(toExpr(value).toScalaColumn()));
+  }
+
+  /**
+   * Converts any value to an Expression. If the value is already a Column, uses its expression
+   * directly. Otherwise, wraps it with lit() to create a Column expression.
+   */
+  private Column toExpr(Object exp) {
+    if (exp instanceof Column) {
+      return ((Column) exp);
+    }
+
+    return Functions.lit(exp);
   }
 }

--- a/src/main/java/com/snowflake/snowpark_java/CaseExpr.java
+++ b/src/main/java/com/snowflake/snowpark_java/CaseExpr.java
@@ -21,7 +21,7 @@ public class CaseExpr extends Column {
 
   /**
    * Appends one more WHEN condition to the CASE expression. This method handles any literal value
-   * and converts it into a `Column`.
+   * and converts it into a `Column` if applies.
    *
    * <p><b>Example:</b>
    *
@@ -34,7 +34,7 @@ public class CaseExpr extends Column {
    * @param condition The case condition
    * @param value The result value in the given condition
    * @return The result case expression
-   * @since 1.17.0
+   * @since 0.12.0
    */
   public CaseExpr when(Column condition, Object value) {
     return new CaseExpr(caseExpr.when(condition.toScalaColumn(), toExpr(value).toScalaColumn()));
@@ -42,7 +42,7 @@ public class CaseExpr extends Column {
 
   /**
    * Sets the default result for this CASE expression. This method handles any literal value and
-   * converts it into a `Column`.
+   * converts it into a `Column` if applies.
    *
    * <p><b>Example:</b>
    *
@@ -55,7 +55,7 @@ public class CaseExpr extends Column {
    * @param value The default value, which can be any literal (e.g., String, int, boolean) or a
    *     `Column`.
    * @return The result column.
-   * @since 1.17.0
+   * @since 0.12.0
    */
   public Column otherwise(Object value) {
     return new Column(caseExpr.otherwise(toExpr(value).toScalaColumn()));

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -4333,7 +4333,7 @@ public final class Functions {
    * @param condition The condition
    * @param value The result value
    * @return The result column
-   * @since 1.17.0
+   * @since 0.12.0
    */
   public static CaseExpr when(Column condition, Object value) {
     return new CaseExpr(

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -4325,19 +4325,20 @@ public final class Functions {
    * <pre>{@code
    * import com.snowflake.snowpark_java.Functions;
    * df.select(Functions
-   *     .when(df.col("col").is_null, Functions.lit(1))
-   *     .when(df.col("col").equal_to(Functions.lit(1)), Functions.lit(6))
+   *     .when(df.col("col").is_null, 1)
+   *     .when(df.col("col").equal_to(Functions.lit(1)), 6)
    *     .otherwise(Functions.lit(7)));
    * }</pre>
    *
-   * @since 0.12.0
    * @param condition The condition
    * @param value The result value
    * @return The result column
+   * @since 1.17.0
    */
-  public static CaseExpr when(Column condition, Column value) {
+  public static CaseExpr when(Column condition, Object value) {
     return new CaseExpr(
-        com.snowflake.snowpark.functions.when(condition.toScalaColumn(), value.toScalaColumn()));
+        com.snowflake.snowpark.functions.when(
+            condition.toScalaColumn(), toExpr(value).toScalaColumn()));
   }
 
   /**
@@ -6037,5 +6038,17 @@ public final class Functions {
   private static UserDefinedFunction userDefinedFunction(
       String funcName, Supplier<UserDefinedFunction> func) {
     return javaUDF("Functions", funcName, "", "", func);
+  }
+
+  /**
+   * Converts any value to an Expression. If the value is already a Column, uses its expression
+   * directly. Otherwise, wraps it with lit() to create a Column expression.
+   */
+  private static Column toExpr(Object exp) {
+    if (exp instanceof Column) {
+      return ((Column) exp);
+    }
+
+    return Functions.lit(exp);
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaColumnSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaColumnSuite.java
@@ -281,6 +281,30 @@ public class JavaColumnSuite extends TestBase {
           Row.create((Object) null),
           Row.create(5)
         });
+
+    // Handling no column type values
+    checkAnswer(
+        df.select(
+            Functions.when(df.col("a").is_null(), 5)
+                .when(df.col("a").equal_to(Functions.lit(1)), 6)
+                .otherwise(7)
+                .as("a")),
+        new Row[] {Row.create(5), Row.create(7), Row.create(6), Row.create(7), Row.create(5)});
+
+    // Handling null values
+    checkAnswer(
+        df.select(
+            Functions.when(df.col("a").is_null(), null)
+                .when(df.col("a").equal_to(Functions.lit(1)), null)
+                .otherwise(null)
+                .as("a")),
+        new Row[] {
+          Row.create((Object) null),
+          Row.create((Object) null),
+          Row.create((Object) null),
+          Row.create((Object) null),
+          Row.create((Object) null)
+        });
   }
 
   @Test

--- a/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
@@ -513,6 +513,51 @@ class ColumnSuite extends TestData {
           .as("a")),
       Seq(Row(5), Row(7), Row(6), Row(7), Row(5)))
 
+    // no column typed value
+    checkAnswer(
+      nullData1.select(
+        functions
+          .when(col("a").is_null, lit(1))
+          .when(col("a") === 1, col("a") / 2)
+          .when(col("a") === 2, col("a") * 2)
+          .when(col("a") === 3, pow(col("a"), 2))
+          .as("a")),
+      Seq(Row(0.5), Row(1.0), Row(1.0), Row(4.0), Row(9.0)))
+
+    checkAnswer(
+      nullData1.select(
+        functions
+          .when(col("a").is_null, "null_value")
+          .when(col("a") <= 2, "lower or equal than two")
+          .when(col("a") >= 3, "greater than two")
+          .as("a")),
+      Seq(
+        Row("greater than two"),
+        Row("lower or equal than two"),
+        Row("lower or equal than two"),
+        Row("null_value"),
+        Row("null_value")))
+
+    // No column otherwise
+    checkAnswer(
+      nullData1.select(
+        functions
+          .when(col("a").is_null, lit(5))
+          .when(col("a") === 1, lit(6))
+          .otherwise(7)
+          .as("a")),
+      Seq(Row(5), Row(7), Row(6), Row(7), Row(5)))
+
+    // Handling nulls
+    checkAnswer(
+      nullData1.select(
+        functions
+          .when(col("a").is_null, null)
+          .when(col("a") === 1, null)
+          .otherwise(null)
+          .as("a")),
+      Seq(Row(null), Row(null), Row(null), Row(null), Row(null)))
+
     // empty otherwise
     checkAnswer(
       nullData1.select(


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes 
[SNOW-2246196](https://snowflakecomputing.atlassian.net/browse/SNOW-2246196)
[SNOW-2245985](https://snowflakecomputing.atlassian.net/browse/SNOW-2245985)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This pull request enhances the usability of the `when` and `otherwise` methods in both the Java and Scala APIs for Snowpark by allowing them to accept any literal value (such as `String`, `int`, `boolean`, or `null`) in addition to `Column` objects. The changes also update documentation and add comprehensive tests to cover these new use cases.

**API Enhancements:**

* The `when` and `otherwise` methods in both Java (`CaseExpr`, `Functions`) and Scala (`CaseExpr`, `functions`) now accept any object or literal, not just `Column` instances. Internally, non-`Column` values are automatically wrapped with `lit()`, making the API more flexible and user-friendly. [[1]](diffhunk://#diff-9d364a3d2c0ed0f1445241aa26099d38d929d2ba542143b6d99786505eb03334L23-R73) [[2]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07L3960-R3973) [[3]](diffhunk://#diff-61451f1177c486a3fd4d60ad699ae7ae45ef4eaee6bada5fcddacca9fce6ba56R767-R831) [[4]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L3255-R3279)

**Documentation Improvements:**

* Updated Javadoc and Scaladoc for `when` and `otherwise` methods to reflect the new accepted value types and to provide clear examples demonstrating the enhanced usage. [[1]](diffhunk://#diff-9d364a3d2c0ed0f1445241aa26099d38d929d2ba542143b6d99786505eb03334L23-R73) [[2]](diffhunk://#diff-61451f1177c486a3fd4d60ad699ae7ae45ef4eaee6bada5fcddacca9fce6ba56R767-R831) [[3]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L3255-R3279)

**Internal Refactoring:**

* Added private helper methods (`toExpr`) in both Java and Scala to handle the conversion of any value to an expression, ensuring consistent implementation and reducing code duplication. [[1]](diffhunk://#diff-9d364a3d2c0ed0f1445241aa26099d38d929d2ba542143b6d99786505eb03334L23-R73) [[2]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07R5674-R5685) [[3]](diffhunk://#diff-61451f1177c486a3fd4d60ad699ae7ae45ef4eaee6bada5fcddacca9fce6ba56R767-R831) [[4]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7R5343-R5350)

**Testing:**

* Expanded test coverage in both Java and Scala test suites to include cases where literals and `null` values are passed to `when` and `otherwise`, verifying correct behavior and output. [[1]](diffhunk://#diff-678f0b7acd2ce9549d3e167440a9837f89d63b9f036faef2f33a93a0b6e30b9fR284-R307) [[2]](diffhunk://#diff-7690e28a68716ffefb40c600d6ba8216614e0550e0a5e85262187ebe4be5eba2R516-R560)


[SNOW-2246196]: https://snowflakecomputing.atlassian.net/browse/SNOW-2246196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNOW-2245985]: https://snowflakecomputing.atlassian.net/browse/SNOW-2245985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ