### PR TITLE
SNOW-2346738: resolve sonaUpload validation failure caused by fat test jar name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,18 @@ lazy val isFipsRelease = {
   // scalastyle:on println
   result
 }
+lazy val includeFatJarsAndBundles = {
+  // When the PUBLISH environment variable is true, we assume the caller is publishing to Maven,
+  // in which case we do not want to include fat JAR, ZIP, or Tarball bundle artifacts.
+  val result = !sys.env.getOrElse("PUBLISH", "false").toBoolean
+  // scalastyle:off println
+  println(s"Including Fat JARs and Bundles in published artifacts: $result")
+  // scalastyle:on println
+  result
+}
+def isFatJarOrBundle(c: String): Boolean =
+  c.contains("with-dependencies") || c.contains("fat-test") || c.contains("bundle")
+
 lazy val snowparkName = s"snowpark${if (isFipsRelease) "-fips" else ""}"
 lazy val jdbcName = s"snowflake-jdbc${if (isFipsRelease) "-fips" else ""}"
 lazy val snowparkVersion = "1.17.0-SNAPSHOT"
@@ -165,13 +177,8 @@ lazy val root = (project in file("."))
 
     // Release settings
 
-    // Release JAR including compiled test classes
-    Test / packageBin / publishArtifact := true,
-    // Also publish a test-sources JAR
-    Test / packageSrc / publishArtifact := true,
-    Test / packageSrc / artifact :=
-      (Compile / packageSrc / artifact).value.withClassifier(Some("tests-sources")),
-    addArtifact(Test / packageSrc / artifact, Test / packageSrc),
+    // Disable publishing the source files JAR
+    Compile / packageSrc / publishArtifact := false,
 
     // Fat JAR settings
     assembly / assemblyJarName :=
@@ -247,6 +254,16 @@ lazy val root = (project in file("."))
       Artifact(name = snowparkName, `type` = "bundle", extension = "tar.gz", classifier = "bundle"),
       Universal / packageZipTarball),
 
+    // Explicitly list checksum files to be generated for visibility
+    checksums := Seq("md5", "sha1"),
+
+    // Filter out bundles and fat jars if publishing to maven
+    artifacts := artifacts.value filter (
+      a => includeFatJarsAndBundles || !isFatJarOrBundle(a.classifier.getOrElse(""))),
+    packagedArtifacts := packagedArtifacts.value filter (
+      af => includeFatJarsAndBundles || !isFatJarOrBundle(af._1.classifier.getOrElse(""))),
+
+    // Signed publish settings
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     // Set up GPG key for release build from environment variable: GPG_HEX_CODE
     // Build jenkins job must have set it, otherwise, the release build will fail.
@@ -256,7 +273,6 @@ lazy val root = (project in file("."))
       Properties.envOrNone("GPG_HEX_CODE").getOrElse("Jenkins_build_not_set_GPG_HEX_CODE"),
       "ignored" // this field is ignored; passwords are supplied by pinentry
     ),
-    // usePgpKeyHex(Properties.envOrElse("GPG_SIGNATURE", "12345")),
     Global / pgpPassphrase := Properties.envOrNone("GPG_KEY_PASSPHRASE").map(_.toCharArray),
     publishMavenStyle := true,
     releaseCrossBuild := true,


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

    Fixes SNOW-2346738
2. Fill out the following pre-review checklist:
    - [ ] I am adding a new automated test(s) to verify correctness of my new code
    - [ ] I am adding new logging messages
    - [ ] I am adding a new telemetry message
    - [ ] I am adding new credentials
    - [ ] I am adding a new dependency
3. Please describe how your code solves the related issue.

    Validation of packages to be release failed due to naming of fat test JAR containing compiled test sources and dependencies. See
    - https://es-ci-legacy-mainvalidation-001.jenkinsdev1.us-west-2.aws-dev.app.snowflake.com/job/MavenPushThunderSnowClient/47/console
    - https://snowflake.slack.com/archives/C054J469AN4/p1758170003398679?thread_ts=1758085517.918489&cid=C054J469AN4

We resolve this issue by changing the SBT artifact publishing commands to now do the following.

- When publishing locally via`sbt +publishLocal`​ or `sbt +publishLocalSigned`​, and for uploading to s3 buckets (`$PUBLISH`​ environment variable must be `false`​ or not set​),  the following artifacts are produced with their associated signature and checksum files:
    - `ivy.xml`​
    - `snowpark_2.1[23].jar`
    - `snowpark_2.1[23].pom`
    - `snowpark_2.1[23]-javadoc.jar`​
    - `snowpark_2.1[23]-scaladoc.jar`
    - `snowpark_2.1[23]-bundle.tar.gz`
    - `snowpark_2.1[23]-bundle.zip`
    - `snowpark_2.1[23]-with-dependencies.jar`
    - `fat-test-snowpark_2.1[23]-fat-test.jar`

- When publishing to Maven central repository via `sbt +publishSigned`​ (`$PUBLISH`​ environment variable must be `true`​), only the following artifacts are produced with their associated signature and checksum files:
    - `ivy.xml`​
    - `snowpark_2.1[23].jar`
    - `snowpark_2.1[23].pom`
    - `snowpark_2.1[23]-javadoc.jar`​
    - `snowpark_2.1[23]-scaladoc.jar`