### PR TITLE
SNOW-2347914: Adding try_to_date and try_to_timestamp overloads to ac…

### DIFF
--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -2452,6 +2452,33 @@ public final class Functions {
    * <p><b>Example:</b>
    *
    * <pre>{@code
+   * SELECT TRY_TO_TIMESTAMP('04/05/2020 01:02:03', lit('mm/dd/yyyy hh24:mi:ss')) as valid,
+   *        TRY_TO_TIMESTAMP('INVALID', lit('mm/dd/yyyy hh24:mi:ss')) as invalid;
+   * +-------------------------+---------+
+   * | VALID                   | INVALID |
+   * |-------------------------+---------|
+   * | 2020-04-05 01:02:03.000 | NULL    |
+   * +-------------------------+---------+
+   * }</pre>
+   *
+   * @param s The input value to be converted to timestamp
+   * @param fmt The time format as Column
+   * @return The result column
+   * @since 1.17.0
+   */
+  public static Column try_to_timestamp(Column s, Column fmt) {
+    return new Column(
+        com.snowflake.snowpark.functions.try_to_timestamp(s.toScalaColumn(), fmt.toScalaColumn()));
+  }
+
+  /**
+   * Wrapper for Snowflake built-in try_to_timestamp function. Converts an input expression into the
+   * corresponding timestamp, but with error-handling support, if the conversion cannot be
+   * performed, it returns a NULL value instead of raising an error.
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
    * SELECT TRY_TO_TIMESTAMP('04/05/2020 01:02:03', 'mm/dd/yyyy hh24:mi:ss') as valid,
    *        TRY_TO_TIMESTAMP('INVALID', 'mm/dd/yyyy hh24:mi:ss') as invalid;
    * +-------------------------+---------+
@@ -2462,13 +2489,12 @@ public final class Functions {
    * }</pre>
    *
    * @param s The input value to be converted to timestamp
-   * @param fmt The time format
+   * @param fmt The time format as String
    * @return The result column
-   * @since 1.17.0
+   * @since 1.18.0
    */
-  public static Column try_to_timestamp(Column s, Column fmt) {
-    return new Column(
-        com.snowflake.snowpark.functions.try_to_timestamp(s.toScalaColumn(), fmt.toScalaColumn()));
+  public static Column try_to_timestamp(Column s, String fmt) {
+    return new Column(com.snowflake.snowpark.functions.try_to_timestamp(s.toScalaColumn(), fmt));
   }
 
   /**
@@ -2527,6 +2553,32 @@ public final class Functions {
    * <p><b>Example:</b>
    *
    * <pre>{@code
+   * SELECT TRY_TO_DATE('2020.07.23', lit('YYYY.MM.DD')) as valid, TRY_TO_DATE('INVALID', lit('YYYY.MM.DD')) as invalid);
+   * +------------+---------+
+   * | VALID      | INVALID |
+   * +------------+---------+
+   * | 2020-07-23 | NULL    |
+   * +------------+---------+
+   * }</pre>
+   *
+   * @param e The input value
+   * @param fmt The time format as Column
+   * @return The result Column object.
+   * @since 1.17.0
+   */
+  public static Column try_to_date(Column e, Column fmt) {
+    return new Column(
+        com.snowflake.snowpark.functions.try_to_date(e.toScalaColumn(), fmt.toScalaColumn()));
+  }
+
+  /**
+   * Wrapper for Snowflake built-in try_to_date function. Converts an input expression to a date,
+   * but with error-handling support (i.e. if the conversion cannot be performed, it returns a NULL
+   * value instead of raising an error)
+   *
+   * <p><b>Example:</b>
+   *
+   * <pre>{@code
    * SELECT TRY_TO_DATE('2020.07.23', 'YYYY.MM.DD') as valid, TRY_TO_DATE('INVALID', 'YYYY.MM.DD') as invalid);
    * +------------+---------+
    * | VALID      | INVALID |
@@ -2536,13 +2588,12 @@ public final class Functions {
    * }</pre>
    *
    * @param e The input value
-   * @param fmt The time format
+   * @param fmt The time format as String
    * @return The result Column object.
-   * @since 1.17.0
+   * @since 1.18.0
    */
-  public static Column try_to_date(Column e, Column fmt) {
-    return new Column(
-        com.snowflake.snowpark.functions.try_to_date(e.toScalaColumn(), fmt.toScalaColumn()));
+  public static Column try_to_date(Column e, String fmt) {
+    return new Column(com.snowflake.snowpark.functions.try_to_date(e.toScalaColumn(), fmt));
   }
 
   /**

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -2119,6 +2119,33 @@ object functions {
    *
    * ===Example===
    * {{{
+   * SELECT TRY_TO_TIMESTAMP('04/05/2020 01:02:03', lit('mm/dd/yyyy hh24:mi:ss')) as valid,
+   *        TRY_TO_TIMESTAMP('INVALID', lit('mm/dd/yyyy hh24:mi:ss')) as invalid;
+   * +-------------------------+---------+
+   * | VALID                   | INVALID |
+   * |-------------------------+---------|
+   * | 2020-04-05 01:02:03.000 | NULL    |
+   * +-------------------------+---------+
+   * }}}
+   *
+   * @param s
+   *   The input value to be converted to timestamp.
+   * @param fmt
+   *   The time format as Column
+   * @return
+   *   The result column.
+   * @group date_func
+   * @since 1.17.0
+   */
+  def try_to_timestamp(s: Column, fmt: Column): Column = builtin("try_to_timestamp")(s, fmt)
+
+  /**
+   * Wrapper for Snowflake built-in try_to_timestamp function. Converts an input expression into the
+   * corresponding timestamp, but with error-handling support, if the conversion cannot be
+   * performed, it returns a NULL value instead of raising an error.
+   *
+   * ===Example===
+   * {{{
    * SELECT TRY_TO_TIMESTAMP('04/05/2020 01:02:03', 'mm/dd/yyyy hh24:mi:ss') as valid,
    *        TRY_TO_TIMESTAMP('INVALID', 'mm/dd/yyyy hh24:mi:ss') as invalid;
    * +-------------------------+---------+
@@ -2131,13 +2158,13 @@ object functions {
    * @param s
    *   The input value to be converted to timestamp.
    * @param fmt
-   *   The time format
+   *   The time format as String
    * @return
    *   The result column.
    * @group date_func
-   * @since 1.17.0
+   * @since 1.18.0
    */
-  def try_to_timestamp(s: Column, fmt: Column): Column = builtin("try_to_timestamp")(s, fmt)
+  def try_to_timestamp(s: Column, fmt: String): Column = builtin("try_to_timestamp")(s, lit(fmt))
 
   /**
    * Converts an input expression to a date.
@@ -2186,6 +2213,33 @@ object functions {
    *
    * ===Example===
    * {{{
+   * SELECT TRY_TO_DATE("2020-05-11", lit("YYYY.MM.DD")) as valid,
+   *        TRY_TO_DATE("invalid", lit("YYYY.MM.DD")) as invalid;
+   * +------------+---------+
+   * | VALID      | INVALID |
+   * |------------+---------|
+   * | 2020-05-11 | NULL    |
+   * +------------+---------+
+   * }}}
+   *
+   * @param e
+   *   The input value to be converted to date.
+   * @param fmt
+   *   The time format as Column
+   * @return
+   *   The result column.
+   * @group date_func
+   * @since 1.17.0
+   */
+  def try_to_date(e: Column, fmt: Column): Column = builtin("try_to_date")(e, fmt)
+
+  /**
+   * Wrapper for Snowflake built-in try_to_date function. Converts an input expression to a date,
+   * but with error-handling support, if the conversion cannot be performed, it returns a NULL value
+   * instead of raising an error.
+   *
+   * ===Example===
+   * {{{
    * SELECT TRY_TO_DATE("2020-05-11", "YYYY.MM.DD") as valid,
    *        TRY_TO_DATE("invalid", "YYYY.MM.DD") as invalid;
    * +------------+---------+
@@ -2198,13 +2252,13 @@ object functions {
    * @param e
    *   The input value to be converted to date.
    * @param fmt
-   *   The time format
+   *   The time format as String
    * @return
    *   The result column.
    * @group date_func
-   * @since 1.17.0
+   * @since 1.18.0
    */
-  def try_to_date(e: Column, fmt: Column): Column = builtin("try_to_date")(e, fmt)
+  def try_to_date(e: Column, fmt: String): Column = builtin("try_to_date")(e, lit(fmt))
 
   /**
    * Creates a date from individual numeric components that represent the year, month, and day of

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -1506,6 +1506,9 @@ public class JavaFunctionSuite extends TestBase {
               df2.select(
                   Functions.try_to_timestamp(df2.col("a"), Functions.lit("mm/dd/yyyy hh24:mi:ss"))),
               expected2);
+          checkAnswer(
+              df2.select(Functions.try_to_timestamp(df2.col("a"), "mm/dd/yyyy hh24:mi:ss")),
+              expected2);
         },
         getSession());
   }
@@ -1541,6 +1544,7 @@ public class JavaFunctionSuite extends TestBase {
           checkAnswer(
               df1.select(Functions.try_to_date(df.col("a"), Functions.lit("YYYY.MM.DD"))),
               expected1);
+          checkAnswer(df1.select(Functions.try_to_date(df.col("a"), "YYYY.MM.DD")), expected1);
         },
         getSession());
   }

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -761,8 +761,11 @@ trait FunctionSuite extends TestData {
       val formatDf = session.sql("select * from values('04/05/2020 01:02:03'),('INVALID') as T(a)")
       val formatDfConverted =
         formatDf.select(try_to_timestamp(col("A"), lit("mm/dd/yyyy hh24:mi:ss")))
+      val stringFormatDfConverted =
+        formatDf.select(try_to_timestamp(col("A"), "mm/dd/yyyy hh24:mi:ss"))
       val formatConvertedExpected = Seq(Row(Timestamp.valueOf("2020-04-05 01:02:03.0")), Row(null))
       checkAnswer(formatDfConverted, formatConvertedExpected)
+      checkAnswer(stringFormatDfConverted, formatConvertedExpected)
     }
   }
 
@@ -805,6 +808,9 @@ trait FunctionSuite extends TestData {
     val df1 = session.sql("select * from values('2020.07.23'),('INVALID') as T(a)")
     checkAnswer(
       df1.select(try_to_date(col("A"), lit("YYYY.MM.DD"))),
+      Seq(Row(new Date(120, 6, 23)), Row(null)))
+    checkAnswer(
+      df1.select(try_to_date(col("A"), "YYYY.MM.DD")),
       Seq(Row(new Date(120, 6, 23)), Row(null)))
   }
 


### PR DESCRIPTION
…cept string format as argument

1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [#SNOW-2347914](https://snowflakecomputing.atlassian.net/browse/SNOW-2347914)

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

This pull request adds new overloads for the `try_to_timestamp` and `try_to_date` functions in both Java and Scala APIs, allowing users to pass the format as a plain `String` in addition to the existing `Column`-based approach. It also updates documentation and test cases to reflect these changes and clarify usage. These improvements make the APIs more flexible and user-friendly.

### API Enhancements

* Added new overloads for `try_to_timestamp` and `try_to_date` in `Functions.java` and `functions.scala` that accept the format as a `String`, making it easier to use these functions without needing to wrap the format in a `Column` (`lit`). [[1]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07R2474-R2499) [[2]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07R2574-R2598) [[3]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2134-R2168) [[4]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2201-R2262)

### Documentation Updates

* Updated JavaDoc and ScalaDoc comments for `try_to_timestamp` and `try_to_date` to clarify the accepted types for the format parameter and to provide examples for both the `Column` and `String` overloads. [[1]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07L2465-R2465) [[2]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07L2539-R2565) [[3]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2134-R2168) [[4]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2201-R2262)

* Revised code examples in documentation to show usage with both `lit()` and plain `String` format arguments for better clarity. [[1]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07L2455-R2456) [[2]](diffhunk://#diff-243c2305d92e31132e6fc5a160408ef164d2d56934e6bf0dd518d23fc3a04f07L2530-R2556) [[3]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2122-R2123) [[4]](diffhunk://#diff-7504c4a89f8d6bfbb616a32a018a8cf8757e6612af34c96847247f36466d99e7L2189-R2217)

### Test Coverage

* Added new test cases in both Java (`JavaFunctionSuite.java`) and Scala (`FunctionSuite.scala`) to verify the new overloads work as expected and produce the same results as the existing `Column` overloads. [[1]](diffhunk://#diff-6e3e6f6477a0760e7b667d4518bfc92a08ad5021660c52e3ffd8761e6937216aR1509-R1511) [[2]](diffhunk://#diff-6e3e6f6477a0760e7b667d4518bfc92a08ad5021660c52e3ffd8761e6937216aR1547) [[3]](diffhunk://#diff-7618f55b5ac77eded89716b0aa76c45709187173aec99047edf071328c733118R764-R768) [[4]](diffhunk://#diff-7618f55b5ac77eded89716b0aa76c45709187173aec99047edf071328c733118R812-R814)
