### PR TITLE
SNOW-3313526: Fix incorrect output from Utils.normalizeStageLocation

### DIFF
--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -167,7 +167,8 @@ object Utils extends Logging {
 
   def normalizeStageLocation(name: String): String = {
     val trimName = name.trim
-    if (SnowflakePathPrefixes.exists(trimName.startsWith(_))) trimName else s"@$trimName"
+    if (SnowflakePathPrefixes.exists(trimName.startsWith(_)) || isSingleQuoted(trimName)) trimName
+    else s"@$trimName"
   }
 
   private def isSingleQuoted(name: String): Boolean =

--- a/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
@@ -240,6 +240,8 @@ class UtilsSuite extends SNTestBase {
     assert(Utils.normalizeStageLocation(name3).equals(name3))
     val name4 = "/some/file.txt"
     assert(Utils.normalizeStageLocation(name4).equals(name4))
+    val name5 = "'@my_stage/path/to/file with spaces.txt'"
+    assert(Utils.normalizeStageLocation(name5).equals(name5))
   }
 
   test("normalizeLocalFile") {


### PR DESCRIPTION
Paths surrounded by single quotes result in incorrect output
