### PR TITLE
SNOW-3215388: fix test set up for UDxFs (#267)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -227,10 +227,26 @@ lazy val root = (project in file("."))
       case _ => MergeStrategy.preferProject
     },
     Test / assembly / assemblyOption ~= { _.withCacheOutput(false) },
-    Test / assemblyPackageScala / assembleArtifact := false, // exclude scala libraries
-    Test / assembly / assemblyExcludedJars := { // exclude snowflake jdbc from the fat jar
+    // For Scala 2.12, sbt-assembly's isScalaLibraryFile treats scala-xml as a core
+    // Scala library and strips it when assemblyPackageScala is false. For 2.13 this
+    // was fixed (scala-xml is no longer part of the 2.13 standard distribution).
+    // ScalaTest 3.2.19 needs scala-xml at runtime, so for 2.12 we enable
+    // assemblyPackageScala and manually exclude only the core JARs we don't want.
+    Test / assemblyPackageScala / assembleArtifact := scalaBinaryVersion.value == "2.12",
+    Test / assembly / assemblyExcludedJars := {
       val cp = (Test / assembly / fullClasspath).value
-      cp filter { _.data.getName == s"$jdbcName-$jdbcVersion.jar" }
+      val baseExcluded = cp filter { _.data.getName == s"$jdbcName-$jdbcVersion.jar" }
+      val scalaCoreExcluded =
+        if (scalaBinaryVersion.value == "2.12") {
+          val scalaV = scalaVersion.value
+          cp filter { att =>
+            Set(
+              s"scala-library-$scalaV.jar",
+              s"scala-reflect-$scalaV.jar",
+              s"scala-compiler-$scalaV.jar").contains(att.data.getName)
+          }
+        } else Nil
+      baseExcluded ++ scalaCoreExcluded
     },
     Test / assembly / fullClasspath ++= (Test / fullClasspath).value,
     // Publish the fat test JAR alongside normal artifacts

--- a/src/main/java/com/snowflake/snowpark_java/Functions.java
+++ b/src/main/java/com/snowflake/snowpark_java/Functions.java
@@ -825,6 +825,171 @@ public final class Functions {
   }
 
   /**
+   * Converts an input expression to a NUMBER value.
+   *
+   * <p>Uses default precision (38) and scale (0).
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @return The result column with the numeric value
+   */
+  public static Column to_number(Column e) {
+    return new Column(com.snowflake.snowpark.functions.to_number(e.toScalaColumn()));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format'.
+   *
+   * <p>Precision and scale are automatically derived from the format string.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format to use to convert numeric values
+   * @return The result column with the numeric value
+   */
+  public static Column to_number(Column e, Column format) {
+    return new Column(
+        com.snowflake.snowpark.functions.to_number(e.toScalaColumn(), format.toScalaColumn()));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format'.
+   *
+   * <p>Precision and scale are automatically derived from the format string.
+   *
+   * <p>This overload accepts the format as a {@link String} and wraps it as a literal column
+   * internally for convenience.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format string to use to convert numeric values
+   * @return The result column with the numeric value
+   */
+  public static Column to_number(Column e, String format) {
+    return to_number(e, lit(format));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format to use to convert numeric values
+   * @param precision The precision (total number of digits)
+   * @param scale The scale (number of digits after the decimal point)
+   * @return The result column with the numeric value
+   */
+  public static Column to_number(Column e, Column format, int precision, int scale) {
+    return new Column(
+        com.snowflake.snowpark.functions.to_number(
+            e.toScalaColumn(), format.toScalaColumn(), precision, scale));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale.
+   *
+   * <p>This overload accepts the format as a {@link String} and wraps it as a literal column
+   * internally for convenience.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format string to use to convert numeric values
+   * @param precision The precision (total number of digits)
+   * @param scale The scale (number of digits after the decimal point)
+   * @return The result column with the numeric value
+   */
+  public static Column to_number(Column e, String format, int precision, int scale) {
+    return to_number(e, lit(format), precision, scale);
+  }
+
+  /**
+   * Converts an input expression to a NUMBER value, with error-handling support. If the conversion
+   * cannot be performed, it returns NULL instead of raising an error.
+   *
+   * <p>Uses default precision (38) and scale (0).
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @return The result column with the numeric value, or NULL if conversion fails
+   */
+  public static Column try_to_number(Column e) {
+    return new Column(com.snowflake.snowpark.functions.try_to_number(e.toScalaColumn()));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format', with error-handling
+   * support. If the conversion cannot be performed, it returns NULL instead of raising an error.
+   *
+   * <p>Precision and scale are automatically derived from the format string.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format to use to convert numeric values
+   * @return The result column with the numeric value, or NULL if conversion fails
+   */
+  public static Column try_to_number(Column e, Column format) {
+    return new Column(
+        com.snowflake.snowpark.functions.try_to_number(e.toScalaColumn(), format.toScalaColumn()));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format', with error-handling
+   * support. If the conversion cannot be performed, it returns NULL instead of raising an error.
+   *
+   * <p>Precision and scale are automatically derived from the format string.
+   *
+   * <p>This overload accepts the format as a {@link String} and wraps it as a literal column
+   * internally for convenience.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format string to use to convert numeric values
+   * @return The result column with the numeric value, or NULL if conversion fails
+   */
+  public static Column try_to_number(Column e, String format) {
+    return try_to_number(e, lit(format));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale, with error-handling support. If the conversion cannot be performed, it returns NULL
+   * instead of raising an error.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format to use to convert numeric values
+   * @param precision The precision (total number of digits)
+   * @param scale The scale (number of digits after the decimal point)
+   * @return The result column with the numeric value, or NULL if conversion fails
+   */
+  public static Column try_to_number(Column e, Column format, int precision, int scale) {
+    return new Column(
+        com.snowflake.snowpark.functions.try_to_number(
+            e.toScalaColumn(), format.toScalaColumn(), precision, scale));
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale, with error-handling support. If the conversion cannot be performed, it returns NULL
+   * instead of raising an error.
+   *
+   * <p>This overload accepts the format as a {@link String} and wraps it as a literal column
+   * internally for convenience.
+   *
+   * @since 1.19.0
+   * @param e The input expression to convert
+   * @param format The format string to use to convert numeric values
+   * @param precision The precision (total number of digits)
+   * @param scale The scale (number of digits after the decimal point)
+   * @return The result column with the numeric value, or NULL if conversion fails
+   */
+  public static Column try_to_number(Column e, String format, int precision, int scale) {
+    return try_to_number(e, lit(format), precision, scale);
+  }
+
+  /**
    * Performs division like the division operator (/), but returns 0 when the divisor is 0 (rather
    * than reporting an error).
    *

--- a/src/main/scala/com/snowflake/snowpark/functions.scala
+++ b/src/main/scala/com/snowflake/snowpark/functions.scala
@@ -737,6 +737,182 @@ object functions {
   }
 
   /**
+   * Converts an input expression to a NUMBER value.
+   *
+   * Uses default precision (38) and scale (0).
+   *
+   * @param e
+   *   The input expression to convert.
+   * @return
+   *   A Column with the numeric value.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def to_number(e: Column): Column = {
+    builtin("to_number")(e)
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format'.
+   *
+   * Precision and scale are automatically derived from the format string.
+   *
+   * @param e
+   *   The input expression to convert.
+   * @param format
+   *   The format to use to convert numeric values.
+   * @return
+   *   A Column with the numeric value.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def to_number(e: Column, format: Column): Column = {
+    val (precision, scale) = resolveToNumberPrecisionAndScale(format)
+    to_number(e, format, precision, scale)
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale.
+   *
+   * @param e
+   *   The input expression to convert.
+   * @param format
+   *   The format to use to convert numeric values.
+   * @param precision
+   *   The precision (total number of digits).
+   * @param scale
+   *   The scale (number of digits after the decimal point).
+   * @return
+   *   A Column with the numeric value.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def to_number(e: Column, format: Column, precision: Int, scale: Int): Column = {
+    builtin("to_number")(e, format, sqlExpr(precision.toString), sqlExpr(scale.toString))
+  }
+
+  /**
+   * Converts an input expression to a NUMBER value, with error-handling support. If the conversion
+   * cannot be performed, it returns NULL instead of raising an error.
+   *
+   * Uses default precision (38) and scale (0).
+   *
+   * @param e
+   *   The input expression to convert.
+   * @return
+   *   A Column with the numeric value, or NULL if conversion fails.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def try_to_number(e: Column): Column = {
+    builtin("try_to_number")(e)
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format', with error-handling
+   * support. If the conversion cannot be performed, it returns NULL instead of raising an error.
+   *
+   * Precision and scale are automatically derived from the format string.
+   *
+   * @param e
+   *   The input expression to convert.
+   * @param format
+   *   The format to use to convert numeric values.
+   * @return
+   *   A Column with the numeric value, or NULL if conversion fails.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def try_to_number(e: Column, format: Column): Column = {
+    val (precision, scale) = resolveToNumberPrecisionAndScale(format)
+    try_to_number(e, format, precision, scale)
+  }
+
+  /**
+   * Converts string 'e' to a number based on the string format 'format' with specified precision
+   * and scale, with error-handling support. If the conversion cannot be performed, it returns NULL
+   * instead of raising an error.
+   *
+   * @param e
+   *   The input expression to convert.
+   * @param format
+   *   The format to use to convert numeric values.
+   * @param precision
+   *   The precision (total number of digits).
+   * @param scale
+   *   The scale (number of digits after the decimal point).
+   * @return
+   *   A Column with the numeric value, or NULL if conversion fails.
+   * @group num_func
+   * @since 1.19.0
+   */
+  def try_to_number(e: Column, format: Column, precision: Int, scale: Int): Column = {
+    builtin("try_to_number")(e, format, sqlExpr(precision.toString), sqlExpr(scale.toString))
+  }
+
+  /**
+   * Resolves the precision and scale from a Column containing a numeric format string literal.
+   *
+   * Extracts the literal string value from the Column and delegates to the String version.
+   *
+   * @param format
+   *   A Column containing a string literal with the numeric format (e.g., lit("$999.99")).
+   * @return
+   *   A tuple containing (precision, scale).
+   * @throws IllegalArgumentException
+   *   if the Column does not contain a string literal.
+   */
+  private[snowpark] def resolveToNumberPrecisionAndScale(format: Column): (Int, Int) = {
+    format.expr match {
+      case Literal(value: String, _) =>
+        resolveToNumberPrecisionAndScale(value)
+      case _ =>
+        throw new IllegalArgumentException(
+          "format must be a string literal Column to derive precision and scale")
+    }
+  }
+
+  /**
+   * Resolves the precision and scale from a numeric format string.
+   *
+   * The precision is the total count of '9' and '0' characters in the format. The scale is the
+   * count of '9' and '0' characters after the decimal point ('.' or 'D').
+   *
+   * @param format
+   *   The numeric format string (e.g., "$999.99", "9999D99").
+   * @return
+   *   A tuple containing (precision, scale).
+   */
+  private[snowpark] def resolveToNumberPrecisionAndScale(format: String): (Int, Int) = {
+    import scala.util.matching.Regex
+    val pattern: Regex = """^(.*?)[.D](.*)$""".r
+    val precision = format.count(c => c == '9' || c == '0')
+    var scale = 0
+    format match {
+      case pattern(_, decimalPart) =>
+        scale = decimalPart.count(c => c == '9' || c == '0')
+      case _ =>
+        scale = 0
+    }
+
+    (precision, scale)
+  }
+
+  /**
+   * Convenience overload of `try_to_number` that accepts a String format and wraps it with `lit`.
+   *
+   * @param e
+   *   The input expression to convert.
+   * @param format
+   *   The format string to use to convert numeric values.
+   * @return
+   *   A Column with the numeric value, or NULL if conversion fails.
+   * @group num_func
+   */
+  def try_to_number(e: Column, format: String): Column = try_to_number(e, lit(format))
+
+  /**
    * Performs division like the division operator (/), but returns 0 when the divisor is 0 (rather
    * than reporting an error).
    *

--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -167,7 +167,8 @@ object Utils extends Logging {
 
   def normalizeStageLocation(name: String): String = {
     val trimName = name.trim
-    if (SnowflakePathPrefixes.exists(trimName.startsWith(_))) trimName else s"@$trimName"
+    if (SnowflakePathPrefixes.exists(trimName.startsWith(_)) || isSingleQuoted(trimName)) trimName
+    else s"@$trimName"
   }
 
   private def isSingleQuoted(name: String): Boolean =

--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -14,6 +14,7 @@ import java.io.{File, FileInputStream}
 import java.lang.invoke.SerializedLambda
 import java.security.{DigestInputStream, MessageDigest}
 import java.util.Locale
+import java.util.regex.Pattern
 import com.snowflake.snowpark.udtf.UDTF
 import net.snowflake.client.jdbc.SnowflakeSQLException
 
@@ -49,6 +50,16 @@ object Utils extends Logging {
     "^SNOWPARK_TEMP_(TABLE|VIEW|STAGE|FUNCTION|TABLE_FUNCTION|FILE_FORMAT|PROCEDURE)_[0-9A-Z]+$"
 
   val SnowflakePathPrefixes: List[String] = List("@", "snow://", "/")
+
+  // regex to identify select and CTE
+  // (https://docs.snowflake.com/en/sql-reference/constructs/with.html)
+  // are select statements in Snowflake.
+  private val SnowflakeSelectSqlPrefixPattern: Pattern =
+    Pattern.compile("^(\\s|\\()*(select|with)", Pattern.CASE_INSENSITIVE)
+  // regex to identify Anonymous stored procedures:
+  // https://docs.snowflake.com/en/sql-reference/sql/call-with
+  private val SnowflakeAnonymousCallWithPattern: Pattern =
+    Pattern.compile("^\\s*with\\s+\\w+\\s+as\\s+procedure\\b", Pattern.CASE_INSENSITIVE)
 
   // Temp object name generation
   val randomGenerator = new Random(System.nanoTime())
@@ -400,6 +411,11 @@ object Utils extends Logging {
     } else {
       false
     }
+
+  private[snowpark] def isSqlSelectStatement(sql: String): Boolean =
+    sql != null &&
+      SnowflakeSelectSqlPrefixPattern.matcher(sql).find() &&
+      !SnowflakeAnonymousCallWithPattern.matcher(sql).find()
 
   private[snowpark] def isStringEmpty(str: String): Boolean = str == null || str.isEmpty
 

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/SnowflakePlan.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/SnowflakePlan.scala
@@ -12,7 +12,11 @@ import com.snowflake.snowpark.internal.{
 import com.snowflake.snowpark.internal.analyzer.SnowflakePlan.wrapException
 import com.snowflake.snowpark.{DataFrame, Row, SaveMode, Session}
 import com.snowflake.snowpark.FileOperationCommand._
-import com.snowflake.snowpark.internal.Utils.{TempObjectType, randomNameForTempObject}
+import com.snowflake.snowpark.internal.Utils.{
+  TempObjectType,
+  isSqlSelectStatement,
+  randomNameForTempObject
+}
 import com.snowflake.snowpark.types.StructType
 import net.snowflake.client.jdbc.SnowflakeSQLException
 
@@ -762,9 +766,7 @@ class SnowflakePlanBuilder(session: Session) extends Logging {
     plan.sourcePlan match {
       case Some(_: SetOperation) => plan
       case Some(_: MultiChildrenNode) => plan
-      // scalastyle:off
-      case _ if plan.queries.last.sql.trim.toLowerCase.startsWith("select") => plan
-      // scalastyle:on
+      case _ if isSqlSelectStatement(plan.queries.last.sql) => plan
       case _ =>
         val newQueries =
           plan.queries :+ Query(resultScanStatement(plan.queries.last.queryIdPlaceHolder))

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/StagedFileWriter.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/StagedFileWriter.scala
@@ -107,9 +107,10 @@ private[snowpark] class StagedFileWriter(val dataframeWriter: DataFrameWriter) e
     //                    TYPE = { CSV | JSON | PARQUET } [ formatTypeOptions ] } ) ]
     // [ copyOptions ]
     // [ HEADER ]
-    s"""COPY INTO $stageLocation
-         | FROM ( $query )
-         | ${getPartitionByClause()}${getFileFormatClause(formatType)}
-         | ${getCopyOptionClause()}${getHeaderClause()}""".stripMargin
+    "COPY INTO " + stageLocation +
+      " FROM ( " + query + " ) " +
+      getPartitionByClause() + getFileFormatClause(formatType) +
+      " " + getCopyOptionClause() +
+      getHeaderClause()
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -742,6 +742,62 @@ public class JavaFunctionSuite extends TestBase {
   }
 
   @Test
+  public void to_number_single_parameter() {
+    DataFrame df = getSession().sql("select * from values('123'),('456') as T(a)");
+    Row[] expected = {Row.create(123L), Row.create(456L)};
+    checkAnswer(df.select(Functions.to_number(df.col("a"))), expected);
+  }
+
+  @Test
+  public void to_number() {
+    DataFrame df = getSession().sql("select * from values('$123.45'),('$67.89') as T(a)");
+    Row[] expected = {
+      Row.create(new java.math.BigDecimal("123.45000000")),
+      Row.create(new java.math.BigDecimal("67.89000000"))
+    };
+    checkAnswer(df.select(Functions.to_number(df.col("a"), Functions.lit("$999.99"))), expected);
+    checkAnswer(df.select(Functions.to_number(df.col("a"), "$999.99")), expected);
+  }
+
+  @Test
+  public void to_number_with_precision_and_scale() {
+    DataFrame df = getSession().sql("select * from values('$123.45'),('$67.89') as T(a)");
+    Row[] expected = {
+      Row.create(new java.math.BigDecimal("123.45")), Row.create(new java.math.BigDecimal("67.89"))
+    };
+    checkAnswer(
+        df.select(Functions.to_number(df.col("a"), Functions.lit("$999.99"), 5, 2)), expected);
+    checkAnswer(df.select(Functions.to_number(df.col("a"), "$999.99", 5, 2)), expected);
+  }
+
+  @Test
+  public void try_to_number_single_parameter() {
+    DataFrame df = getSession().sql("select * from values('123'),('INVALID') as T(a)");
+    Row[] expected = {Row.create(123L), Row.create((Object) null)};
+    checkAnswer(df.select(Functions.try_to_number(df.col("a"))), expected);
+  }
+
+  @Test
+  public void try_to_number() {
+    DataFrame df = getSession().sql("select * from values('$123.45'),('INVALID') as T(a)");
+    Row[] expected = {
+      Row.create(new java.math.BigDecimal("123.45000000")), Row.create((Object) null)
+    };
+    checkAnswer(
+        df.select(Functions.try_to_number(df.col("a"), Functions.lit("$999.99"))), expected);
+    checkAnswer(df.select(Functions.try_to_number(df.col("a"), "$999.99")), expected);
+  }
+
+  @Test
+  public void try_to_number_with_precision_and_scale() {
+    DataFrame df = getSession().sql("select * from values('$123.45'),('INVALID') as T(a)");
+    Row[] expected = {Row.create(new java.math.BigDecimal("123.45")), Row.create((Object) null)};
+    checkAnswer(
+        df.select(Functions.try_to_number(df.col("a"), Functions.lit("$999.99"), 5, 2)), expected);
+    checkAnswer(df.select(Functions.try_to_number(df.col("a"), "$999.99", 5, 2)), expected);
+  }
+
+  @Test
   public void div0() {
     DataFrame df = getSession().sql("select * from values(0) as T(a)");
     Row[] expected = {Row.create(0.0, 2.0)};

--- a/src/test/java/com/snowflake/snowpark_test/TestFunctions.java
+++ b/src/test/java/com/snowflake/snowpark_test/TestFunctions.java
@@ -15,17 +15,24 @@ public abstract class TestFunctions {
   protected void withTimeZoneTest(TestMethod thunk, Session session) {
     String sysTimeZone = System.getProperty("user.timezone", "");
     TimeZone oldTimeZone = TimeZone.getDefault();
+    boolean isStoredProc =
+        (Boolean) JavaToScalaConvertor.javaToScalaSession(session).conn().isStoredProc();
     String oldSfTimezone =
-        session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect()[0].getString(1);
+        isStoredProc
+            ? session.sql("select CURRENT_TIMEZONE()").collect()[0].getString(0)
+            : session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect()[0].getString(1);
+    String testTimezone = isStoredProc ? oldSfTimezone : "America/Los_Angeles";
     try {
-      System.setProperty("user.timezone", "America/Los_Angeles");
-      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-      session.sql("alter session set TIMEZONE = 'America/Los_Angeles'").collect();
+      System.setProperty("user.timezone", testTimezone);
+      TimeZone.setDefault(TimeZone.getTimeZone(testTimezone));
+      if (!isStoredProc)
+        session.sql(String.format("alter session set TIMEZONE = '%s'", testTimezone)).collect();
       thunk.run();
     } finally {
       System.setProperty("user.timezone", sysTimeZone);
       TimeZone.setDefault(oldTimeZone);
-      session.sql("alter session set TIMEZONE = '" + oldSfTimezone + "'").collect();
+      if (!isStoredProc)
+        session.sql("alter session set TIMEZONE = '" + oldSfTimezone + "'").collect();
     }
   }
 

--- a/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
+++ b/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
@@ -22,6 +22,9 @@ public abstract class UDFTestBase extends TestFunctions {
 
   protected Session createSession() {
     Session newSession = Session.builder().configFile(defaultProfile).create();
+    newSession
+        .sql("alter session set ENABLE_FIX_SNOW_3011194_SCALA_VERSIONED_HANDLER_NAMES=true")
+        .collect();
     if (JavaUtils.snowparkScalaCompatVersion().equals("2.13")) {
       newSession.sql("alter session set ENABLE_SCALA_UDF_RUNTIME_2_13=true").collect();
     }

--- a/src/test/scala/com/snowflake/snowpark/APIInternalSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/APIInternalSuite.scala
@@ -319,7 +319,7 @@ class APIInternalSuite extends TestData {
   }
 
   test("close session") {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     assert(Session.getActiveSession.nonEmpty)
     newSession.close()
     assert(

--- a/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
+++ b/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
@@ -199,16 +199,25 @@ trait SNTestBase extends AnyFunSuite with BeforeAndAfterAll with SFTestUtils wit
     val sysTimeZone = System.getProperty("user.timezone", "")
     val defaultTimezone = TimeZone.getDefault
     val oldSfTimeZone =
-      session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
+      if (isStoredProc(session)) {
+        session.sql("select CURRENT_TIMEZONE()").collect().head.getString(0)
+      } else {
+        session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
+      }
+    val testTimezone = if (isStoredProc(session)) oldSfTimeZone else timezone
     try {
-      System.setProperty("user.timezone", timezone)
-      TimeZone.setDefault(TimeZone.getTimeZone(timezone))
-      session.runQuery(s"alter session set TIMEZONE = '$timezone'")
+      System.setProperty("user.timezone", testTimezone)
+      TimeZone.setDefault(TimeZone.getTimeZone(testTimezone))
+      if (!isStoredProc(session)) {
+        session.runQuery(s"alter session set TIMEZONE = '$testTimezone'")
+      }
       thunk
     } finally {
       System.setProperty("user.timezone", sysTimeZone)
       TimeZone.setDefault(defaultTimezone)
-      session.runQuery(s"alter session set TIMEZONE = '$oldSfTimeZone'")
+      if (!isStoredProc(session)) {
+        session.runQuery(s"alter session set TIMEZONE = '$oldSfTimeZone'")
+      }
     }
   }
 

--- a/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
+++ b/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
@@ -84,11 +84,20 @@ trait SNTestBase extends AnyFunSuite with BeforeAndAfterAll with SFTestUtils wit
     TypeMap("geography", "geography", Types.VARCHAR, GeographyType),
     TypeMap("geometry", "geometry", Types.VARCHAR, GeometryType))
 
-  implicit lazy val session: Session = {
-    TestUtils.tryToLoadFipsProvider()
+  protected def getBaseSession(configs: (String, String)*): Session = {
     val session = Session.builder
       .configFile(defaultProfile)
+      .configs(configs.toMap)
       .create
+    runQuery(
+      "alter session set ENABLE_FIX_SNOW_3011194_SCALA_VERSIONED_HANDLER_NAMES=true",
+      session)
+    session
+  }
+
+  implicit lazy val session: Session = {
+    TestUtils.tryToLoadFipsProvider()
+    val session = getBaseSession()
     // trigger this lazy parameter to make some tests more stable
     // e.g. count queries
     session.conn.hideInternalAlias
@@ -346,36 +355,24 @@ trait SnowTestFiles {
 
 trait LazySession extends SNTestBase {
   implicit override lazy val session: Session =
-    Session.builder
-      .configFile(defaultProfile)
-      .config(SnowparkLazyAnalysis, "true")
-      .create
+    getBaseSession((SnowparkLazyAnalysis, "true"))
 }
 
 trait EagerSession extends SNTestBase {
   implicit override lazy val session: Session =
-    Session.builder
-      .configFile(defaultProfile)
-      .config(SnowparkLazyAnalysis, "false")
-      .create
+    getBaseSession((SnowparkLazyAnalysis, "false"))
 }
 
 trait AlwaysCleanSession extends SNTestBase {
   implicit override lazy val session: Session =
-    Session.builder
-      .configFile(defaultProfile)
-      .config(ParameterUtils.SnowparkEnableClosureCleaner, "always")
-      .create
+    getBaseSession((ParameterUtils.SnowparkEnableClosureCleaner, "always"))
 }
 
 // No need to add trait 'repl_only', because in Intellij's test, 'repl_only' is
 // equivalent with 'never'
 trait NeverCleanSession extends SNTestBase {
   implicit override lazy val session: Session =
-    Session.builder
-      .configFile(defaultProfile)
-      .config(ParameterUtils.SnowparkEnableClosureCleaner, "never")
-      .create
+    getBaseSession((ParameterUtils.SnowparkEnableClosureCleaner, "never"))
 }
 
 trait UploadTimeoutSession extends SNTestBase {

--- a/src/test/scala/com/snowflake/snowpark/TestData.scala
+++ b/src/test/scala/com/snowflake/snowpark/TestData.scala
@@ -8,11 +8,17 @@ trait TestData extends SNTestBase {
   val sysTimeZone = System.getProperty("user.timezone", "")
   val defaultTimezone = TimeZone.getDefault
   val oldSfTimeZone =
-    session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
-
-  System.setProperty("user.timezone", "America/Los_Angeles")
-  TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
-  session.runQuery(s"alter session set TIMEZONE = 'America/Los_Angeles'")
+    if (isStoredProc(session)) {
+      session.sql("select CURRENT_TIMEZONE()").collect().head.getString(0)
+    } else {
+      session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
+    }
+  val testTimezone = if (isStoredProc(session)) oldSfTimeZone else "America/Los_Angeles"
+  System.setProperty("user.timezone", testTimezone)
+  TimeZone.setDefault(TimeZone.getTimeZone(testTimezone))
+  if (!isStoredProc(session)) {
+    session.runQuery(s"alter session set TIMEZONE = '$testTimezone'")
+  }
 
   val variant1: DataFrame =
     session.sql(
@@ -77,7 +83,9 @@ trait TestData extends SNTestBase {
 
   System.setProperty("user.timezone", sysTimeZone)
   TimeZone.setDefault(defaultTimezone)
-  session.runQuery(s"alter session set TIMEZONE = '$oldSfTimeZone'")
+  if (!isStoredProc(session)) {
+    session.runQuery(s"alter session set TIMEZONE = '$oldSfTimeZone'")
+  }
 
   lazy val testData1: DataFrame =
     session.createDataFrame(Seq(Data(1, true, "a"), Data(2, false, "b")))

--- a/src/test/scala/com/snowflake/snowpark/UDFClasspathSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDFClasspathSuite.scala
@@ -95,7 +95,7 @@ class UDFClasspathSuite extends SNTestBase {
   test(
     "Test that snowpark jar is automatically added" +
       " if there is classNotFound error in first attempt") {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     TestUtils.addDepsToClassPath(newSession)
     val udfR = spy(new UDXRegistrationHandler(newSession))
     val path = UDFClassPath.getPathForClass(classOf[com.snowflake.snowpark.Session]).get

--- a/src/test/scala/com/snowflake/snowpark/UDFInternalSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDFInternalSuite.scala
@@ -12,7 +12,7 @@ import java.sql.SQLException
 class UDFInternalSuite extends TestData {
 
   lazy private val stageName: String = randomName()
-  lazy private val newSession = Session.builder.configFile(defaultProfile).create
+  lazy private val newSession = getBaseSession()
 
   override def beforeAll: Unit = {
     super.beforeAll
@@ -31,7 +31,7 @@ class UDFInternalSuite extends TestData {
   }
 
   test("Test temp udf not failing back to upload jar", JavaStoredProcExclude) {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     val mockSession = spy(newSession)
     TestUtils.addDepsToClassPath(mockSession, None, usePackages = true)
     val path = UDFClassPath.getPathForClass(classOf[com.snowflake.snowpark.Session]).get
@@ -52,7 +52,7 @@ class UDFInternalSuite extends TestData {
   }
 
   test("Test permanent udf not failing back to upload jar", JavaStoredProcExclude) {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     val mockSession = spy(newSession)
     TestUtils.addDepsToClassPath(mockSession, None, usePackages = true)
     val path = UDFClassPath.getPathForClass(classOf[com.snowflake.snowpark.Session]).get
@@ -86,7 +86,7 @@ class UDFInternalSuite extends TestData {
   }
 
   test("Test add version logic", JavaStoredProcExclude) {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     val mockSession = spy(newSession)
     TestUtils.addTestDepsToClassPath(mockSession, None)
     when(mockSession.isVersionSupportedByServerPackages).thenReturn(true)

--- a/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
@@ -588,6 +588,19 @@ class UtilsSuite extends SNTestBase {
     assert(!Utils.isPutOrGetCommand("show table "))
   }
 
+  test("Utils.isSqlSelectStatement") {
+    // positive test
+    assert(Utils.isSqlSelectStatement("select 1"))
+    assert(Utils.isSqlSelectStatement("  ( select 1 )"))
+    assert(Utils.isSqlSelectStatement("with t as (select 1) select * from t"))
+
+    // negative test
+    assert(!Utils.isSqlSelectStatement(null))
+    assert(!Utils.isSqlSelectStatement(""))
+    assert(!Utils.isSqlSelectStatement("show tables"))
+    assert(!Utils.isSqlSelectStatement("with p as procedure() returns string language sql as $$"))
+  }
+
   test("Utils.isStringEmpty") {
     assert(Utils.isStringEmpty(null))
     assert(Utils.isStringEmpty(""))

--- a/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
@@ -240,6 +240,8 @@ class UtilsSuite extends SNTestBase {
     assert(Utils.normalizeStageLocation(name3).equals(name3))
     val name4 = "/some/file.txt"
     assert(Utils.normalizeStageLocation(name4).equals(name4))
+    val name5 = "'@my_stage/path/to/file with spaces.txt'"
+    assert(Utils.normalizeStageLocation(name5).equals(name5))
   }
 
   test("normalizeLocalFile") {

--- a/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
@@ -21,7 +21,7 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
     Seq(StructField("a", IntegerType), StructField("b", StringType), StructField("c", DoubleType)))
 
   // session to verify permanent udf
-  lazy private val newSession = Session.builder.configFile(defaultProfile).create
+  lazy private val newSession = getBaseSession()
 
   override def beforeAll: Unit = {
     super.beforeAll
@@ -205,7 +205,7 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
   }
 
   test("test AsyncJob isRunning() and cancel()") {
-    val session2 = Session.builder.configFile(defaultProfile).create
+    val session2 = getBaseSession()
     try {
       // positive test
       val asyncJob = session.sql("select SYSTEM$WAIT(3)").async.collect()
@@ -312,7 +312,7 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
   }
 
   test("session.createAsyncJob(queryID)") {
-    val session2 = Session.builder.configFile(defaultProfile).create
+    val session2 = getBaseSession()
     try {
       // positive test
       val queryID = session.range(5).async.collect().getQueryId()

--- a/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
@@ -526,6 +526,46 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
     }
   }
 
+  test("async saveAsTable from CTE query") {
+    val sourceTable = randomName()
+    val targetTable = randomName()
+    try {
+      createTable(sourceTable, "c1 int, c2 string")
+      runQuery(s"insert into $sourceTable values (1, 'one'), (2, 'two')", session)
+
+      val cteDf =
+        session.sql(s"with products as (select c1, c2 from $sourceTable) select * from products")
+      cteDf.write.mode(SaveMode.Overwrite).async.saveAsTable(targetTable).getResult()
+      checkAnswer(session.table(targetTable), Seq(Row(1, "one"), Row(2, "two")))
+    } finally {
+      dropTable(sourceTable)
+      dropTable(targetTable)
+    }
+  }
+
+  test("async: write JSON files from CTE query") {
+    val sourceTable = randomName()
+    val path = s"@$targetStageName/cte_json_${Random.nextInt().abs}"
+    try {
+      createTable(sourceTable, "c1 int, c2 string")
+      runQuery(s"insert into $sourceTable values (1, 'one'), (2, 'two')", session)
+      val cteDf = session.sql(
+        s"with products as (select c1, c2 from $sourceTable) select c1, c2 from products")
+      val jsonDf = cteDf.select(array_construct(col("C1"), col("C2")))
+
+      val writeResult = jsonDf.write.mode(SaveMode.Overwrite).async.json(path).getResult()
+      assert(writeResult.rows.length == 1 && writeResult.rows.head.getInt(0) == 2)
+
+      val resultFiles = session.sql(s"ls $path").collect()
+      assert(resultFiles.length == 1 && resultFiles(0).getString(0).endsWith(".json.gz"))
+      checkAnswer(
+        session.read.json(path),
+        Seq(Row("[\n  1,\n  \"one\"\n]"), Row("[\n  2,\n  \"two\"\n]")))
+    } finally {
+      dropTable(sourceTable)
+    }
+  }
+
   // Copy UpdatableSuite.test("update rows in table") and
   // modify it to run update() in async mode
   test("update rows in table (async)") {

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameNonStoredProcSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameNonStoredProcSuite.scala
@@ -35,7 +35,10 @@ class DataFrameNonStoredProcSuite extends TestData {
       assert(
         dateReverseCrosstabResult(1).toSeq.drop(1).map(_.asInstanceOf[Long]).sorted == Seq(0L, 1L))
       checkAnswer(
-        string7.stat.crosstab("a", "b").sort(col("a")),
+        string7.stat
+          .crosstab("a", "b")
+          .select(col("a"), col("CAST(1 AS NUMBER(38,0))"), col("CAST(2 AS NUMBER(38,0))"))
+          .sort(col("a")),
         Seq(Row(null, 0, 1), Row("str", 1, 0)))
       // Pivot column order is non-deterministic (depends on GROUP BY result order).
       // Check pivot values as a sorted set to make the test order-independent.

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
@@ -1472,7 +1472,7 @@ trait DataFrameSuite extends TestData with BeforeAndAfterEach {
       checkAnswer(session.table(quoteName(viewName2)), Seq(Row(1), Row(2), Row(3)))
 
       // check if it is session temporary
-      val newSession = Session.builder.configFile(defaultProfile).create
+      val newSession = getBaseSession()
       val msg = intercept[SnowflakeSQLException](newSession.table(viewName).show())
       assert(msg.getMessage.contains("does not exist or not authorized"))
     } finally {

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameWriterSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameWriterSuite.scala
@@ -595,4 +595,27 @@ class DataFrameWriterSuite extends TestData {
         Row("{\n  \"_COL_0\": 1,\n  \"_COL_1\": \"one\"\n}"),
         Row("{\n  \"_COL_0\": 2,\n  \"_COL_1\": \"two\"\n}")))
   }
+
+  test("csv with || string concatenation in SQL") {
+    val df = session.sql("""SELECT 'John'
+        || ' '
+        || 'Doe' as FULLNAME""")
+    val path = s"@$targetStageName/pipe_csv_${Random.nextInt().abs}"
+    val writeResult = df.write.csv(path)
+    assert(writeResult.rows.head.getLong(0) == 1) // 1 row unloaded
+    val readSchema = StructType(Seq(StructField("FULLNAME", StringType)))
+    val readDf = session.read.schema(readSchema).csv(path)
+    checkAnswer(readDf, Seq(Row("John Doe")))
+  }
+
+  test("json with || string concatenation in SQL") {
+    val df = session.sql("""SELECT TO_VARIANT('John'
+        || ' '
+        || 'Doe') as FULLNAME""")
+    val path = s"@$targetStageName/pipe_json_${Random.nextInt().abs}"
+    val writeResult = df.write.json(path)
+    assert(writeResult.rows.head.getLong(0) == 1) // 1 row unloaded
+    val readDf = session.read.json(path)
+    checkAnswer(readDf, Seq(Row("\"John Doe\"")))
+  }
 }

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -811,6 +811,47 @@ trait FunctionSuite extends TestData {
     checkAnswer(df1.select(try_to_date(col("A"), "YYYY.MM.DD")), expected)
   }
 
+  test("to_number single parameter") {
+    val df = session.sql("select * from values('123'),('456') as T(a)")
+    checkAnswer(df.select(to_number(col("A"))), Seq(Row(123L), Row(456L)))
+  }
+
+  test("to_number") {
+    val df = session.sql("select * from values('$123.45'),('$67.89') as T(a)")
+    checkAnswer(
+      df.select(to_number(col("A"), lit("$999.99"))),
+      Seq(Row(BigDecimal("123.45000000").bigDecimal), Row(BigDecimal("67.89000000").bigDecimal)))
+  }
+
+  test("to_number with precision and scale") {
+    val df = session.sql("select * from values('$123.45'),('$67.89') as T(a)")
+    checkAnswer(
+      df.select(to_number(col("A"), lit("$999.99"), 5, 2)),
+      Seq(Row(BigDecimal("123.45").bigDecimal), Row(BigDecimal("67.89").bigDecimal)))
+  }
+
+  test("try_to_number single parameter") {
+    val df = session.sql("select * from values('123'),('INVALID') as T(a)")
+    checkAnswer(df.select(try_to_number(col("A"))), Seq(Row(123L), Row(null)))
+  }
+
+  test("try_to_number") {
+    val df = session.sql("select * from values('$123.45'),('INVALID') as T(a)")
+    checkAnswer(
+      df.select(try_to_number(col("A"), lit("$999.99"))),
+      Seq(Row(BigDecimal("123.45000000").bigDecimal), Row(null)))
+    checkAnswer(
+      df.select(try_to_number(col("A"), "$999.99")),
+      Seq(Row(BigDecimal("123.45000000").bigDecimal), Row(null)))
+  }
+
+  test("try_to_number with precision and scale") {
+    val df = session.sql("select * from values('$123.45'),('INVALID') as T(a)")
+    checkAnswer(
+      df.select(try_to_number(col("A"), lit("$999.99"), 5, 2)),
+      Seq(Row(BigDecimal("123.45").bigDecimal), Row(null)))
+  }
+
   test("date_trunc") {
     testWithTimezone() {
       checkAnswer(

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
@@ -14,7 +14,7 @@ import java.util.jar.JarOutputStream
 class PermanentUDFSuite extends TestData {
 
   // session to verify permanent udf
-  lazy private val newSession = Session.builder.configFile(defaultProfile).create
+  lazy private val newSession = getBaseSession()
   lazy private val stageName: String = randomName()
 
   // create test target directory

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
@@ -14,7 +14,7 @@ class PermanentUDTFSuite extends TestData {
   import session.implicits._
 
   // session to verify permanent udf
-  lazy private val newSession = Session.builder.configFile(defaultProfile).create
+  lazy private val newSession = getBaseSession()
   lazy private val stageName: String = randomStageName()
   val wordCountTableName = randomTableName()
 

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -33,14 +33,14 @@ class SessionSuite extends SNTestBase {
   test("Test for create with multiple threads") {
     val t1 = new Thread {
       override def run {
-        val t1Session = Session.builder.configFile(defaultProfile).create
+        val t1Session = getBaseSession()
         assert(t1Session != session)
       }
     }
 
     val t2 = new Thread {
       override def run {
-        val t2Session = Session.builder.configFile(defaultProfile).create
+        val t2Session = getBaseSession()
         assert(t2Session != session)
       }
     }
@@ -160,7 +160,7 @@ class SessionSuite extends SNTestBase {
   }
 
   test("DataFrame created before session close are not usable after closing the session") {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     val df = newSession.range(10)
     val read = newSession.read
     newSession.close()
@@ -325,7 +325,7 @@ class SessionSuite extends SNTestBase {
   }
 
   test("The app name is not defined") {
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     assert(getParameterValue("query_tag", newSession) == "")
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
@@ -1027,7 +1027,7 @@ class StoredProcedureSuite extends SNTestBase {
   test("permanent is permanent") {
     val spName = randomName()
     val stageName = randomName()
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     try {
       createStage(stageName, isTemporary = false)
       session.sproc.registerPermanent(
@@ -2206,7 +2206,7 @@ println(s"""
     assert(session.sql(s"show procedures like '$name1'").collect().length == 1)
     assert(session.sql(s"show procedures like '$name2'").collect().length == 1)
 
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
     // SPs don't exist in other sessions
     assert(newSession.sql(s"show procedures like '$name1'").collect().isEmpty)
     assert(newSession.sql(s"show procedures like '$name2'").collect().isEmpty)

--- a/src/test/scala/com/snowflake/snowpark_test/UDTFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/UDTFSuite.scala
@@ -2043,7 +2043,7 @@ class UDTFSuite extends TestData {
         StructType(StructField("word", StringType), StructField("count", IntegerType))
     }
 
-    var newSession = Session.builder.configFile(defaultProfile).create
+    var newSession = getBaseSession()
     try {
       // Use UDTF and then UDF
       TestUtils.addDepsToClassPath(newSession)
@@ -2056,7 +2056,7 @@ class UDTFSuite extends TestData {
       newSession.close()
 
       // Use UDF and then UDTF
-      newSession = Session.builder.configFile(defaultProfile).create
+      newSession = getBaseSession()
       TestUtils.addDepsToClassPath(newSession)
       val udf2 = newSession.udf.registerTemporary((x: Int) => x + x)
       val df4 = newSession.sql(s"select ${udf2.name.get}(20)")

--- a/src/test/scala/com/snowflake/test/QueryTagSuite.scala
+++ b/src/test/scala/com/snowflake/test/QueryTagSuite.scala
@@ -11,7 +11,7 @@ class QueryTagSuite extends SNTestBase {
 
   test("Test that query tag is not set if it is already set") {
     // Have to create a new session, else the lazy val `queryTagIsSet` is reused
-    val newSession = Session.builder.configFile(defaultProfile).create
+    val newSession = getBaseSession()
 
     val someTag = randomName()
     super.runQuery(s"alter session set query_tag ='$someTag'", newSession)


### PR DESCRIPTION
SNOW-3215388: fix test set up for UDxFs (#267)

- SNOW-3215388: fix test set up for Scala 2.13
- SNOW-3215388: enable parameter for all tests

SNOW-3200177: fix a bug that CTE query is not considered select query (#266)

SNOW-3050119: Add to_number and try_to_number functions (#264)

SNOW-3298550: Fix COPY INTO sqlgen bug due to stripMargin (#274)

- SNOW-3298550: Fix COPY INTO sqlgen bug due to stripMargin
- address comments

SNOW-3313526: Fix incorrect output from Utils.normalizeStageLocation (#275)

SNOW-3313526: Fix incorrect output from Utils.normalizeStageLocation due to single-quoted stage paths

fix sbt to include scala xml in 2.12 and skip altering timezone in sp  (#277)

- fix sbt to include scala xml in 2.12
- skip timezone setting
- update comment
- address comments
- fix formatting

---

Co-authored-by: Hemit Shah [hemit.shah@snowflake.com](mailto:hemit.shah@snowflake.com)