### PR TITLE
SNOW-3511808: Escape single quotes in subfieldExpression and singleQuote

### DIFF
--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -206,8 +206,19 @@ package object analyzer {
   private[analyzer] def inExpression(column: String, values: Seq[String]): String =
     column + _In + blockExpression(values)
 
-  private[analyzer] def subfieldExpression(expr: String, field: String): String =
-    expr + _LeftBracket + _SingleQuote + field + _SingleQuote + _RightBracket
+  /**
+   * Emits a Snowflake `expr['field']` subfield access. The documented API contract for
+   * `Column.subField(String)` is that callers escape embedded single quotes themselves (by doubling
+   * them) before passing the field name in — see the comment in `ColumnSuite.subfield`. We respect
+   * that: an already-well-formed escaped body (every `'` doubled) is embedded verbatim, otherwise
+   * we double the embedded `'`s ourselves before wrapping. The latter branch is what closes the
+   * SNOW-3511808 injection: a payload such as `x'] || (SELECT …) || ['y` is unescaped, so its `'`s
+   * get doubled and the entire payload stays contained in one well-formed SQL string literal.
+   */
+  private[analyzer] def subfieldExpression(expr: String, field: String): String = {
+    val safeField = if (hasOnlyEscapedQuotes(field)) field else escapeSingleQuotes(field)
+    expr + _LeftBracket + _SingleQuote + safeField + _SingleQuote + _RightBracket
+  }
 
   private[analyzer] def subfieldExpression(expr: String, field: Int): String =
     expr + _LeftBracket + field + _RightBracket
@@ -778,13 +789,61 @@ package object analyzer {
         .map(window => _Over + _LeftParenthesis + window + _RightParenthesis)
         .getOrElse(_EmptyString) + _RightParenthesis
 
-  def singleQuote(value: String): String = {
-    if (value.startsWith(_SingleQuote) && value.endsWith(_SingleQuote)) {
-      value
-    } else {
-      _SingleQuote + value + _SingleQuote
+  /**
+   * Wraps a value in single quotes for use as a Snowflake SQL string literal.
+   *
+   * Pre-quoted inputs (values that already form a well-formed SQL string literal — i.e. start and
+   * end with `'`, with every internal `'` doubled) are passed through unchanged. This preserves the
+   * long-standing API contract that callers may supply either a bare value or a pre-formatted
+   * literal (e.g. `FIELD_DELIMITER -> "'aa'"` in `DataFrameWriter.options`). Inputs that are not
+   * well-formed literals are wrapped, with any embedded single quotes doubled via
+   * [[escapeSingleQuotes]].
+   *
+   * SECURITY (SNOW-3511808): the earlier implementation pass-through trusted any string that merely
+   * started and ended with `'`, which made payloads such as `'a'; DROP TABLE x; --'` (well-bounded
+   * but containing an unescaped interior quote that breaks out of the literal scope) appear safe.
+   * The stricter [[isProperlyQuoted]] check below rejects those, and the wrapping branch now
+   * consistently escapes embedded quotes.
+   */
+  def singleQuote(value: String): String =
+    if (isProperlyQuoted(value)) value
+    else _SingleQuote + escapeSingleQuotes(value) + _SingleQuote
+
+  /**
+   * True iff `value` is a well-formed Snowflake single-quoted SQL string literal: it starts and
+   * ends with `'`, and every single quote in the interior is doubled (`''`). An empty literal
+   * (`"''"`) is considered well-formed. See [[singleQuote]] for the security rationale.
+   */
+  private[analyzer] def isProperlyQuoted(value: String): Boolean =
+    value.length >= 2 &&
+      value.startsWith(_SingleQuote) &&
+      value.endsWith(_SingleQuote) &&
+      hasOnlyEscapedQuotes(value.substring(1, value.length - 1))
+
+  private def hasOnlyEscapedQuotes(body: String): Boolean = {
+    var i = 0
+    var ok = true
+    while (ok && i < body.length) {
+      if (body.charAt(i) == '\'') {
+        if (i + 1 < body.length && body.charAt(i + 1) == '\'') {
+          i += 2
+        } else {
+          ok = false
+        }
+      } else {
+        i += 1
+      }
     }
+    ok
   }
+
+  /**
+   * Doubles single quotes inside a value so it is safe to embed inside a Snowflake single-quoted
+   * SQL string literal. Used by [[singleQuote]] and [[subfieldExpression]] to defend against SQL
+   * injection (SNOW-3511808).
+   */
+  private[analyzer] def escapeSingleQuotes(value: String): String =
+    value.replace(_SingleQuote, _SingleQuote + _SingleQuote)
 
   /**
    * Use this function to normalize all user input and client generated names

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -802,8 +802,9 @@ package object analyzer {
 
   /**
    * True iff `value` is a well-formed Snowflake single-quoted SQL string literal: it starts and
-   * ends with `'`, and every single quote in the interior is doubled (`''`). An empty literal
-   * (`"''"`) is considered well-formed.
+   * ends with `'`, and every interior single quote is either doubled (`''`) or backslash-escaped
+   * (`\'`) -- Snowflake accepts both forms inside `'...'` literals. An empty literal (`"''"`) is
+   * considered well-formed.
    */
   private[analyzer] def isStringLiteralProperlySingleQuoted(value: String): Boolean =
     value.length >= 2 &&
@@ -821,6 +822,9 @@ package object analyzer {
         } else {
           ok = false
         }
+      } else if (body.charAt(i) == '\\' && i + 1 < body.length &&
+        body.charAt(i + 1) == '\'') {
+        i += 2
       } else {
         i += 1
       }

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -207,24 +207,10 @@ package object analyzer {
     column + _In + blockExpression(values)
 
   /**
-   * Emits a Snowflake `expr['field']` subfield access. There are two paths:
-   *
-   *   1. Pass-through (backward-compat with the historical single-quote API contract): if the
-   *      caller-supplied `field` is already a well-formed escaped body (every embedded `'` is
-   *      doubled — the contract documented in `ColumnSuite.subfield`), it is wrapped verbatim
-   *      between single quotes. This preserves the exact SQL previously emitted for such inputs. 2.
-   *      Otherwise (the common case): the field is wrapped using [[dollarQuoteOrEscape]] —
-   *      Snowflake's dollar-quoted string syntax (`$$…$$`), which is not subject to any internal
-   *      escape interpretation. This closes the SNOW-3511808 injection family (the original `x'] ||
-   *      (SELECT …) || ['y` payload and the `\'; DROP TABLE x; --` backslash bypass identified
-   *      during PR review) without our having to enumerate Snowflake's lexer escape table — `$$`
-   *      simply doesn't have one.
-   *
-   * Edge case: a `field` of exactly `"''"` is, by the contract above, a well-formed escaped body
-   * representing the one-character field name `'`. It therefore takes path (1) and is emitted as
-   * `expr['''']`. A caller that actually wants the two-character field name `''` must double both
-   * quotes themselves and pass `"''''"`, producing `expr['''''']`. Both are covered in
-   * `SqlInjectionSuite`.
+   * Emits `expr['field']` for variant/struct/map subfield access (SNOW-3511808). Field names that
+   * are already well-formed escaped bodies (per the `ColumnSuite.subfield` contract: every interior
+   * `'` doubled) are wrapped verbatim in single quotes; everything else flows through
+   * [[dollarQuoteOrEscape]].
    */
   private[analyzer] def subfieldExpression(expr: String, field: String): String = {
     val literal =
@@ -233,9 +219,6 @@ package object analyzer {
     expr + _LeftBracket + literal + _RightBracket
   }
 
-  // The Int overload needs no escaping: an integer cannot break out of the surrounding
-  // `[...]` syntax or carry an unescaped quote, so it is emitted directly between the
-  // brackets without single-quote wrapping (subfield access by ordinal, not by name).
   private[analyzer] def subfieldExpression(expr: String, field: Int): String =
     expr + _LeftBracket + field + _RightBracket
 
@@ -806,33 +789,15 @@ package object analyzer {
         .getOrElse(_EmptyString) + _RightParenthesis
 
   /**
-   * Wraps a value as a Snowflake SQL string literal. Three paths, ordered to minimise textual SQL
-   * churn vs the pre-fix output:
+   * Wraps a value as a Snowflake SQL string literal (SNOW-3511808). Three paths, ordered to
+   * minimise textual SQL churn vs the pre-fix output:
    *
-   *   1. Pass-through (backward-compat with the historical single-quote API contract): if the
-   *      caller-supplied `value` is already a well-formed single-quoted SQL string literal — i.e.
-   *      starts and ends with `'`, with every interior `'` doubled — it is returned unchanged. This
-   *      preserves the long-standing contract that callers may supply either a bare value or a
-   *      pre-formatted literal (e.g. `FIELD_DELIMITER -> "'aa'"` in `DataFrameWriter.options`). 2.
-   *      Bare single-quote wrap (the common case): if the value contains neither `'` nor `\`, plain
-   *      `'value'` wrapping is already safe — no `'` means no way to break out of the literal, no
-   *      `\` means no way to trigger Snowflake's `\'` alternative-quote escape. We keep emitting
-   *      the textually-unchanged `'value'` form so downstream consumers that do string-equality
-   *      comparisons against the canonical single-quoted form (e.g. `DataFrameWriter`'s
-   *      `columnOrder` validator, which checks against `Set("'index'", "'name'")` and
-   *      pattern-matches on `case "'name'"` a few lines below) keep working unchanged. 3. Otherwise
-   *      (value contains `'` and/or `\` — the SNOW-3511808 vector): the value is wrapped using
-   *      [[dollarQuoteOrEscape]], which uses Snowflake's dollar-quoted string syntax (`$$…$$`).
-   *      Dollar-quoted literals perform NO internal escape interpretation, so neither the
-   *      `'`-closing bypass (`x'; DROP TABLE …`) nor the `\'`-escape bypass (`\'; DROP TABLE …`,
-   *      identified in PR #281 review) is reachable.
-   *
-   * SECURITY (SNOW-3511808): the earlier implementation pass-through trusted any string that merely
-   * started and ended with `'`, which made payloads such as `'a'; DROP TABLE x; --'` (well-bounded
-   * but containing an unescaped interior quote that breaks out of the literal scope) appear safe.
-   * The stricter [[isProperlyQuoted]] check rejects those, and any input that contains `'` or `\`
-   * is routed through dollar-quoting — the escape-table-free alternative — so neither `'`-only nor
-   * `\'`-based bypasses survive.
+   *   1. If `value` is already a well-formed pre-quoted literal (per [[isProperlyQuoted]]), pass it
+   *      through unchanged. 2. If `value` contains neither `'` nor `\`, emit bare `'value'` —
+   *      textually identical to the pre-fix output, which downstream string-equality checks rely on
+   *      (e.g. `DataFrameWriter`'s `columnOrder` validator on `Set("'index'", "'name'")`). 3.
+   *      Otherwise (the attack surface, including the PR #281 `\'` bypass), wrap via
+   *      [[dollarQuoteOrEscape]].
    */
   def singleQuote(value: String): String =
     if (isProperlyQuoted(value)) value
@@ -868,23 +833,11 @@ package object analyzer {
   }
 
   /**
-   * Wraps a value as a Snowflake string literal using dollar-quoting (`$$…$$`) whenever that is
-   * safe, falling back to a fully-escaped single-quoted literal in the rare case the value cannot
-   * be dollar-quoted.
-   *
-   * Why dollar-quoting is the primary path: inside `$$…$$`, Snowflake performs NO escape
-   * interpretation. Backslashes and single quotes are ordinary characters; the only thing that
-   * terminates the string is the closing `$$` (see
-   * https://docs.snowflake.com/en/sql-reference/data-types-text — "Dollar-quoted string
-   * constants"). That means we do not need to enumerate the lexer's escape table, and we are
-   * resilient to future escape-sequence additions — the SNOW-3511808 fix becomes structural rather
-   * than character-by-character.
-   *
-   * Dollar-quoting is NOT safe when the value either contains `$$` (the embedded `$$` would close
-   * the literal early) or ends with `$` (concatenating `$$` after a trailing `$` produces `$$$`,
-   * which the lexer reads as a closing `$$` followed by an extraneous `$`). In either case we fall
-   * back to a single-quoted literal with both backslashes and single quotes escaped via
-   * [[escapeForSingleQuotedLiteral]] — still safe, just less elegant.
+   * Wraps a value as a Snowflake string literal using dollar-quoting (`$$…$$`), which performs no
+   * internal escape interpretation (the structural defence against SNOW-3511808). Falls back to a
+   * fully-escaped single-quoted literal via [[escapeForSingleQuotedLiteral]] when dollar-quoting is
+   * unsafe: either the value contains `$$` (which would close the literal early) or it ends with
+   * `$` (which would combine with our trailing `$$` into a malformed `$$$`).
    */
   private[analyzer] def dollarQuoteOrEscape(value: String): String =
     if (value.contains("$$") || value.endsWith("$"))
@@ -893,22 +846,10 @@ package object analyzer {
       "$$" + value + "$$"
 
   /**
-   * Escapes a value so it is safe to embed inside a Snowflake single-quoted SQL string literal.
-   * Used by [[dollarQuoteOrEscape]] in the fallback path when dollar-quoting is unsafe.
-   *
-   * Both backslashes and single quotes must be escaped, in that order, because Snowflake's
-   * single-quoted string lexer interprets backslash as an escape character — for example `\'` is an
-   * alternative encoding of `'` and `\b` is BACKSPACE (see
-   * https://docs.snowflake.com/en/sql-reference/data-types-text — "Escape sequences in
-   * single-quoted string constants"). Without backslash-doubling, a payload like `\'; DROP TABLE x;
-   * --` would survive `'`-only escaping (the doubled `''` is still preceded by an unescaped `\`, so
-   * the lexer reads `\'` as a single `'` inside the literal, the next `'` closes the literal, and
-   * the trailing `;` terminates the statement). Doubling backslashes first turns `\\` into `\\\\`,
-   * which Snowflake re-reads as a single literal `\\`, so the following `''` is unambiguously a
-   * doubled-quote escape.
-   *
-   * Order (backslashes before single quotes) does not affect correctness — neither operation
-   * introduces the other character — but the convention is "escape the escape character first".
+   * Doubles backslashes then single quotes so the value is safe to embed in a Snowflake
+   * single-quoted SQL string literal. Both are necessary because Snowflake's lexer treats `\` as an
+   * escape character (e.g. `\'` is an alternative encoding of `'`), so a quotes-only strategy is
+   * bypassable (SNOW-3511808 PR #281).
    */
   private[analyzer] def escapeForSingleQuotedLiteral(value: String): String =
     value

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -207,23 +207,30 @@ package object analyzer {
     column + _In + blockExpression(values)
 
   /**
-   * Emits a Snowflake `expr['field']` subfield access. The documented API contract for
-   * `Column.subField(String)` is that callers escape embedded single quotes themselves (by doubling
-   * them) before passing the field name in — see the comment in `ColumnSuite.subfield`. We respect
-   * that: an already-well-formed escaped body (every `'` doubled) is embedded verbatim, otherwise
-   * we double the embedded `'`s ourselves before wrapping. The latter branch is what closes the
-   * SNOW-3511808 injection: a payload such as `x'] || (SELECT …) || ['y` is unescaped, so its `'`s
-   * get doubled and the entire payload stays contained in one well-formed SQL string literal.
+   * Emits a Snowflake `expr['field']` subfield access. There are two paths:
+   *
+   *   1. Pass-through (backward-compat with the historical single-quote API contract): if the
+   *      caller-supplied `field` is already a well-formed escaped body (every embedded `'` is
+   *      doubled — the contract documented in `ColumnSuite.subfield`), it is wrapped verbatim
+   *      between single quotes. This preserves the exact SQL previously emitted for such inputs. 2.
+   *      Otherwise (the common case): the field is wrapped using [[dollarQuoteOrEscape]] —
+   *      Snowflake's dollar-quoted string syntax (`$$…$$`), which is not subject to any internal
+   *      escape interpretation. This closes the SNOW-3511808 injection family (the original `x'] ||
+   *      (SELECT …) || ['y` payload and the `\'; DROP TABLE x; --` backslash bypass identified
+   *      during PR review) without our having to enumerate Snowflake's lexer escape table — `$$`
+   *      simply doesn't have one.
    *
    * Edge case: a `field` of exactly `"''"` is, by the contract above, a well-formed escaped body
-   * representing the one-character field name `'`. It therefore passes through verbatim, producing
+   * representing the one-character field name `'`. It therefore takes path (1) and is emitted as
    * `expr['''']`. A caller that actually wants the two-character field name `''` must double both
    * quotes themselves and pass `"''''"`, producing `expr['''''']`. Both are covered in
    * `SqlInjectionSuite`.
    */
   private[analyzer] def subfieldExpression(expr: String, field: String): String = {
-    val safeField = if (hasOnlyEscapedQuotes(field)) field else escapeSingleQuotes(field)
-    expr + _LeftBracket + _SingleQuote + safeField + _SingleQuote + _RightBracket
+    val literal =
+      if (hasOnlyEscapedQuotes(field)) _SingleQuote + field + _SingleQuote
+      else dollarQuoteOrEscape(field)
+    expr + _LeftBracket + literal + _RightBracket
   }
 
   // The Int overload needs no escaping: an integer cannot break out of the surrounding
@@ -799,24 +806,38 @@ package object analyzer {
         .getOrElse(_EmptyString) + _RightParenthesis
 
   /**
-   * Wraps a value in single quotes for use as a Snowflake SQL string literal.
+   * Wraps a value as a Snowflake SQL string literal. Three paths, ordered to minimise textual SQL
+   * churn vs the pre-fix output:
    *
-   * Pre-quoted inputs (values that already form a well-formed SQL string literal — i.e. start and
-   * end with `'`, with every internal `'` doubled) are passed through unchanged. This preserves the
-   * long-standing API contract that callers may supply either a bare value or a pre-formatted
-   * literal (e.g. `FIELD_DELIMITER -> "'aa'"` in `DataFrameWriter.options`). Inputs that are not
-   * well-formed literals are wrapped, with any embedded single quotes doubled via
-   * [[escapeSingleQuotes]].
+   *   1. Pass-through (backward-compat with the historical single-quote API contract): if the
+   *      caller-supplied `value` is already a well-formed single-quoted SQL string literal — i.e.
+   *      starts and ends with `'`, with every interior `'` doubled — it is returned unchanged. This
+   *      preserves the long-standing contract that callers may supply either a bare value or a
+   *      pre-formatted literal (e.g. `FIELD_DELIMITER -> "'aa'"` in `DataFrameWriter.options`). 2.
+   *      Bare single-quote wrap (the common case): if the value contains neither `'` nor `\`, plain
+   *      `'value'` wrapping is already safe — no `'` means no way to break out of the literal, no
+   *      `\` means no way to trigger Snowflake's `\'` alternative-quote escape. We keep emitting
+   *      the textually-unchanged `'value'` form so downstream consumers that do string-equality
+   *      comparisons against the canonical single-quoted form (e.g. `DataFrameWriter`'s
+   *      `columnOrder` validator, which checks against `Set("'index'", "'name'")` and
+   *      pattern-matches on `case "'name'"` a few lines below) keep working unchanged. 3. Otherwise
+   *      (value contains `'` and/or `\` — the SNOW-3511808 vector): the value is wrapped using
+   *      [[dollarQuoteOrEscape]], which uses Snowflake's dollar-quoted string syntax (`$$…$$`).
+   *      Dollar-quoted literals perform NO internal escape interpretation, so neither the
+   *      `'`-closing bypass (`x'; DROP TABLE …`) nor the `\'`-escape bypass (`\'; DROP TABLE …`,
+   *      identified in PR #281 review) is reachable.
    *
    * SECURITY (SNOW-3511808): the earlier implementation pass-through trusted any string that merely
    * started and ended with `'`, which made payloads such as `'a'; DROP TABLE x; --'` (well-bounded
    * but containing an unescaped interior quote that breaks out of the literal scope) appear safe.
-   * The stricter [[isProperlyQuoted]] check below rejects those, and the wrapping branch now
-   * consistently escapes embedded quotes.
+   * The stricter [[isProperlyQuoted]] check rejects those, and any input that contains `'` or `\`
+   * is routed through dollar-quoting — the escape-table-free alternative — so neither `'`-only nor
+   * `\'`-based bypasses survive.
    */
   def singleQuote(value: String): String =
     if (isProperlyQuoted(value)) value
-    else _SingleQuote + escapeSingleQuotes(value) + _SingleQuote
+    else if (value.indexOf('\'') >= 0 || value.indexOf('\\') >= 0) dollarQuoteOrEscape(value)
+    else _SingleQuote + value + _SingleQuote
 
   /**
    * True iff `value` is a well-formed Snowflake single-quoted SQL string literal: it starts and
@@ -847,14 +868,52 @@ package object analyzer {
   }
 
   /**
-   * Doubles single quotes inside a value so it is safe to embed inside a Snowflake single-quoted
-   * SQL string literal. Used by [[singleQuote]] and [[subfieldExpression]] to defend against SQL
-   * injection (SNOW-3511808). `String.replace(CharSequence, CharSequence)` replaces every
-   * occurrence (not just the first — that would be `replaceFirst` on the regex-based API), which is
-   * exactly the all-quotes-must-be-doubled semantics SQL requires.
+   * Wraps a value as a Snowflake string literal using dollar-quoting (`$$…$$`) whenever that is
+   * safe, falling back to a fully-escaped single-quoted literal in the rare case the value cannot
+   * be dollar-quoted.
+   *
+   * Why dollar-quoting is the primary path: inside `$$…$$`, Snowflake performs NO escape
+   * interpretation. Backslashes and single quotes are ordinary characters; the only thing that
+   * terminates the string is the closing `$$` (see
+   * https://docs.snowflake.com/en/sql-reference/data-types-text — "Dollar-quoted string
+   * constants"). That means we do not need to enumerate the lexer's escape table, and we are
+   * resilient to future escape-sequence additions — the SNOW-3511808 fix becomes structural rather
+   * than character-by-character.
+   *
+   * Dollar-quoting is NOT safe when the value either contains `$$` (the embedded `$$` would close
+   * the literal early) or ends with `$` (concatenating `$$` after a trailing `$` produces `$$$`,
+   * which the lexer reads as a closing `$$` followed by an extraneous `$`). In either case we fall
+   * back to a single-quoted literal with both backslashes and single quotes escaped via
+   * [[escapeForSingleQuotedLiteral]] — still safe, just less elegant.
    */
-  private[analyzer] def escapeSingleQuotes(value: String): String =
-    value.replace(_SingleQuote, _SingleQuote + _SingleQuote)
+  private[analyzer] def dollarQuoteOrEscape(value: String): String =
+    if (value.contains("$$") || value.endsWith("$"))
+      _SingleQuote + escapeForSingleQuotedLiteral(value) + _SingleQuote
+    else
+      "$$" + value + "$$"
+
+  /**
+   * Escapes a value so it is safe to embed inside a Snowflake single-quoted SQL string literal.
+   * Used by [[dollarQuoteOrEscape]] in the fallback path when dollar-quoting is unsafe.
+   *
+   * Both backslashes and single quotes must be escaped, in that order, because Snowflake's
+   * single-quoted string lexer interprets backslash as an escape character — for example `\'` is an
+   * alternative encoding of `'` and `\b` is BACKSPACE (see
+   * https://docs.snowflake.com/en/sql-reference/data-types-text — "Escape sequences in
+   * single-quoted string constants"). Without backslash-doubling, a payload like `\'; DROP TABLE x;
+   * --` would survive `'`-only escaping (the doubled `''` is still preceded by an unescaped `\`, so
+   * the lexer reads `\'` as a single `'` inside the literal, the next `'` closes the literal, and
+   * the trailing `;` terminates the statement). Doubling backslashes first turns `\\` into `\\\\`,
+   * which Snowflake re-reads as a single literal `\\`, so the following `''` is unambiguously a
+   * doubled-quote escape.
+   *
+   * Order (backslashes before single quotes) does not affect correctness — neither operation
+   * introduces the other character — but the convention is "escape the escape character first".
+   */
+  private[analyzer] def escapeForSingleQuotedLiteral(value: String): String =
+    value
+      .replace("\\", "\\\\")
+      .replace(_SingleQuote, _SingleQuote + _SingleQuote)
 
   /**
    * Use this function to normalize all user input and client generated names

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -214,12 +214,21 @@ package object analyzer {
    * we double the embedded `'`s ourselves before wrapping. The latter branch is what closes the
    * SNOW-3511808 injection: a payload such as `x'] || (SELECT …) || ['y` is unescaped, so its `'`s
    * get doubled and the entire payload stays contained in one well-formed SQL string literal.
+   *
+   * Edge case: a `field` of exactly `"''"` is, by the contract above, a well-formed escaped body
+   * representing the one-character field name `'`. It therefore passes through verbatim, producing
+   * `expr['''']`. A caller that actually wants the two-character field name `''` must double both
+   * quotes themselves and pass `"''''"`, producing `expr['''''']`. Both are covered in
+   * `SqlInjectionSuite`.
    */
   private[analyzer] def subfieldExpression(expr: String, field: String): String = {
     val safeField = if (hasOnlyEscapedQuotes(field)) field else escapeSingleQuotes(field)
     expr + _LeftBracket + _SingleQuote + safeField + _SingleQuote + _RightBracket
   }
 
+  // The Int overload needs no escaping: an integer cannot break out of the surrounding
+  // `[...]` syntax or carry an unescaped quote, so it is emitted directly between the
+  // brackets without single-quote wrapping (subfield access by ordinal, not by name).
   private[analyzer] def subfieldExpression(expr: String, field: Int): String =
     expr + _LeftBracket + field + _RightBracket
 
@@ -840,7 +849,9 @@ package object analyzer {
   /**
    * Doubles single quotes inside a value so it is safe to embed inside a Snowflake single-quoted
    * SQL string literal. Used by [[singleQuote]] and [[subfieldExpression]] to defend against SQL
-   * injection (SNOW-3511808).
+   * injection (SNOW-3511808). `String.replace(CharSequence, CharSequence)` replaces every
+   * occurrence (not just the first — that would be `replaceFirst` on the regex-based API), which is
+   * exactly the all-quotes-must-be-doubled semantics SQL requires.
    */
   private[analyzer] def escapeSingleQuotes(value: String): String =
     value.replace(_SingleQuote, _SingleQuote + _SingleQuote)

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/package.scala
@@ -207,16 +207,16 @@ package object analyzer {
     column + _In + blockExpression(values)
 
   /**
-   * Emits `expr['field']` for variant/struct/map subfield access (SNOW-3511808). Field names that
-   * are already well-formed escaped bodies (per the `ColumnSuite.subfield` contract: every interior
-   * `'` doubled) are wrapped verbatim in single quotes; everything else flows through
-   * [[dollarQuoteOrEscape]].
+   * Emits `expr['field']` for variant/struct/map subfield access. Field names that already form a
+   * well-formed single-quoted body (per the `ColumnSuite.subfield` contract: every `'` doubled) are
+   * wrapped verbatim; otherwise we escape embedded single quotes ourselves before wrapping. The
+   * latter branch closes the closing-quote injection (e.g. `x'] || (SELECT ...) || ['y`).
    */
   private[analyzer] def subfieldExpression(expr: String, field: String): String = {
-    val literal =
-      if (hasOnlyEscapedQuotes(field)) _SingleQuote + field + _SingleQuote
-      else dollarQuoteOrEscape(field)
-    expr + _LeftBracket + literal + _RightBracket
+    val body =
+      if (hasOnlyEscapedSingleQuotes(field)) field
+      else escapeSingleQuotesForSingleQuotedLiteral(field)
+    expr + _LeftBracket + _SingleQuote + body + _SingleQuote + _RightBracket
   }
 
   private[analyzer] def subfieldExpression(expr: String, field: Int): String =
@@ -789,33 +789,29 @@ package object analyzer {
         .getOrElse(_EmptyString) + _RightParenthesis
 
   /**
-   * Wraps a value as a Snowflake SQL string literal (SNOW-3511808). Three paths, ordered to
-   * minimise textual SQL churn vs the pre-fix output:
-   *
-   *   1. If `value` is already a well-formed pre-quoted literal (per [[isProperlyQuoted]]), pass it
-   *      through unchanged. 2. If `value` contains neither `'` nor `\`, emit bare `'value'` —
-   *      textually identical to the pre-fix output, which downstream string-equality checks rely on
-   *      (e.g. `DataFrameWriter`'s `columnOrder` validator on `Set("'index'", "'name'")`). 3.
-   *      Otherwise (the attack surface, including the PR #281 `\'` bypass), wrap via
-   *      [[dollarQuoteOrEscape]].
+   * Wraps a value as a Snowflake SQL string literal. Pre-quoted inputs that already form a
+   * well-formed literal (per [[isStringLiteralProperlySingleQuoted]]) pass through unchanged, so
+   * callers may supply either a bare value or a pre-formatted literal (e.g. `FIELD_DELIMITER ->
+   * "'aa'"` in `DataFrameWriter.options`). All other inputs are wrapped with any embedded `'`
+   * escaped (doubled) via [[escapeSingleQuotesForSingleQuotedLiteral]], which is what closes the
+   * closing-quote injection.
    */
   def singleQuote(value: String): String =
-    if (isProperlyQuoted(value)) value
-    else if (value.indexOf('\'') >= 0 || value.indexOf('\\') >= 0) dollarQuoteOrEscape(value)
-    else _SingleQuote + value + _SingleQuote
+    if (isStringLiteralProperlySingleQuoted(value)) value
+    else _SingleQuote + escapeSingleQuotesForSingleQuotedLiteral(value) + _SingleQuote
 
   /**
    * True iff `value` is a well-formed Snowflake single-quoted SQL string literal: it starts and
    * ends with `'`, and every single quote in the interior is doubled (`''`). An empty literal
-   * (`"''"`) is considered well-formed. See [[singleQuote]] for the security rationale.
+   * (`"''"`) is considered well-formed.
    */
-  private[analyzer] def isProperlyQuoted(value: String): Boolean =
+  private[analyzer] def isStringLiteralProperlySingleQuoted(value: String): Boolean =
     value.length >= 2 &&
       value.startsWith(_SingleQuote) &&
       value.endsWith(_SingleQuote) &&
-      hasOnlyEscapedQuotes(value.substring(1, value.length - 1))
+      hasOnlyEscapedSingleQuotes(value.substring(1, value.length - 1))
 
-  private def hasOnlyEscapedQuotes(body: String): Boolean = {
+  private def hasOnlyEscapedSingleQuotes(body: String): Boolean = {
     var i = 0
     var ok = true
     while (ok && i < body.length) {
@@ -833,28 +829,12 @@ package object analyzer {
   }
 
   /**
-   * Wraps a value as a Snowflake string literal using dollar-quoting (`$$…$$`), which performs no
-   * internal escape interpretation (the structural defence against SNOW-3511808). Falls back to a
-   * fully-escaped single-quoted literal via [[escapeForSingleQuotedLiteral]] when dollar-quoting is
-   * unsafe: either the value contains `$$` (which would close the literal early) or it ends with
-   * `$` (which would combine with our trailing `$$` into a malformed `$$$`).
+   * Doubles every single quote so the value is safe to embed inside a Snowflake single-quoted SQL
+   * string literal. Defends against the closing-quote injection class without altering any other
+   * character in `value`.
    */
-  private[analyzer] def dollarQuoteOrEscape(value: String): String =
-    if (value.contains("$$") || value.endsWith("$"))
-      _SingleQuote + escapeForSingleQuotedLiteral(value) + _SingleQuote
-    else
-      "$$" + value + "$$"
-
-  /**
-   * Doubles backslashes then single quotes so the value is safe to embed in a Snowflake
-   * single-quoted SQL string literal. Both are necessary because Snowflake's lexer treats `\` as an
-   * escape character (e.g. `\'` is an alternative encoding of `'`), so a quotes-only strategy is
-   * bypassable (SNOW-3511808 PR #281).
-   */
-  private[analyzer] def escapeForSingleQuotedLiteral(value: String): String =
-    value
-      .replace("\\", "\\\\")
-      .replace(_SingleQuote, _SingleQuote + _SingleQuote)
+  private[analyzer] def escapeSingleQuotesForSingleQuotedLiteral(value: String): String =
+    value.replace(_SingleQuote, _SingleQuote + _SingleQuote)
 
   /**
    * Use this function to normalize all user input and client generated names

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -163,4 +163,81 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(escapeSingleQuotes("a'b") == "a''b")
     assert(escapeSingleQuotes("don't") == "don''t")
   }
+
+  // ---- boundary tests requested in PR review (SNOW-3511808) ----------------
+
+  test("singleQuote: empty literal '' passes through unchanged") {
+    // Boundary case: the two-character input `''` is a well-formed empty SQL
+    // string literal. `isProperlyQuoted` accepts it, so it round-trips as-is.
+    // Without this guarantee, a caller that explicitly passed the empty
+    // literal would see it re-wrapped to `''''` (a literal containing one
+    // single quote), changing its semantics.
+    assert(singleQuote("''") == "''")
+  }
+
+  test("subfieldExpression: Int overload needs no escaping") {
+    // The `(expr: String, field: Int)` overload addresses array/struct fields
+    // by ordinal. Integers cannot carry quote characters and cannot escape
+    // the surrounding `[...]` syntax, so this overload deliberately bypasses
+    // the string-quoting path and emits the integer directly. This test is
+    // here so a future reader of `SqlInjectionSuite` does not wonder whether
+    // the overload was accidentally left unprotected.
+    assert(subfieldExpression("data", 0) == "data[0]")
+    assert(subfieldExpression("data", 42) == "data[42]")
+    assert(subfieldExpression("data", -1) == "data[-1]")
+  }
+
+  // ---- call-site coverage: confirm callers of singleQuote are protected ----
+  //
+  // The fix to `singleQuote` defends every call site that funnels user input
+  // through it. We assert this end-to-end for each known call site in
+  // `package.scala`: `collateExpression`, `selectFromPathWithFormatStatement`,
+  // and `copyIntoTable`. Each test uses an adversarial input that would
+  // previously have terminated the literal early and injected SQL; the fix
+  // contains the entire payload inside a single well-formed string literal.
+
+  test("collateExpression escapes an injected collation spec (SNOW-3511808 side-fix)") {
+    // collationSpec flows from `Column.collate(String)` — a public API. Pre-fix
+    // `singleQuote` would have passed `"en_US'; DROP TABLE x; --"` through with
+    // only the bare wrap, embedding raw `'` characters into the emitted SQL
+    // and breaking out of the literal scope on the second `'`.
+    val sql = collateExpression("col", "en_US'; DROP TABLE x; --")
+    assert(sql == "col COLLATE 'en_US''; DROP TABLE x; --'")
+  }
+
+  test("selectFromPathWithFormatStatement escapes injected formatName and pattern") {
+    val sql = selectFromPathWithFormatStatement(
+      project = Seq.empty,
+      path = "@stage",
+      formatName = Some("MY_FMT'; DROP TABLE x; --"),
+      pattern = Some(".*csv'; DROP TABLE y; --"))
+    // Asserting the exact emitted string is brittle (the surrounding builder
+    // is dense with spaces); the security property is that both option values
+    // were funneled through `singleQuote`, doubled their interior `'`, and
+    // landed in the SQL as well-formed single-quoted literals.
+    assert(sql.contains("'MY_FMT''; DROP TABLE x; --'"))
+    assert(sql.contains("'.*csv''; DROP TABLE y; --'"))
+    // And nothing got past with a raw, unescaped quote in the payload region.
+    assert(!sql.contains("'MY_FMT';"))
+    assert(!sql.contains("'.*csv';"))
+  }
+
+  test("copyIntoTable escapes an injected COPY INTO pattern") {
+    val sql = copyIntoTable(
+      tableName = "T",
+      filePath = "@stage",
+      format = "CSV",
+      formatTypeOptions = Map.empty,
+      copyOptions = Map.empty,
+      pattern = Some(".*csv'; DROP TABLE x; --"),
+      columnNames = Seq.empty,
+      transformations = Seq.empty)
+    // The injected `'` inside the pattern is doubled, so the payload stays
+    // contained inside a single well-formed SQL string literal.
+    assert(sql.contains("'.*csv''; DROP TABLE x; --'"))
+    // Same property as above: the unescaped `'.*csv';` substring (which
+    // would indicate the literal was terminated early at the injection
+    // point) must not appear anywhere in the emitted SQL.
+    assert(!sql.contains("'.*csv';"))
+  }
 }

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -3,163 +3,73 @@ package com.snowflake.snowpark.internal.analyzer
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
- * Regression tests for SNOW-3511808: SQL injection via unescaped field name in
- * `subfieldExpression`, and an over-permissive pre-quoted pass-through in `singleQuote`.
- *
- * Both helpers share a single guiding principle: respect the long-standing API contract that
- * callers may pre-escape their input, but never let a non-well-formed input through unescaped (the
- * injection vector). The gates are [[hasOnlyEscapedQuotes]] (for `subfieldExpression` field bodies)
- * and [[isProperlyQuoted]] (for `singleQuote` whole-literal inputs). Inputs that don't pass the
- * gate go through [[dollarQuoteOrEscape]], which wraps the value in Snowflake's dollar-quoted
- * string syntax (`$$…$$`) — a delimiter that performs NO internal escape interpretation. That
- * eliminates the SNOW-3511808 injection family in one stroke without our having to enumerate
- * Snowflake's lexer escape table.
- *
- * `subfieldExpression` historically embedded the caller-supplied field name directly between single
- * quotes inside `[...]`. The documented contract is that callers escape embedded single quotes
- * themselves (see the comment in `ColumnSuite.subfield`: "User need to escape single quote with two
- * single quotes"). A field name that violates that contract — i.e. contains unescaped `'` — could
- * close the literal early and inject arbitrary SQL. Post-fix, pre-escaped bodies still pass through
- * wrapped in `'…'` for backward compat; everything else is dollar-quoted, so neither `'` nor `\'`
- * (the backslash-quote-escape variant identified in PR #281 review by
- * @sfc-gh-heshah)
- *   can break out of the literal.
- *
- * `singleQuote` historically returned any input that started AND ended with `'` unchanged, on the
- * assumption that the caller had already produced a safe literal. That trusted strings like `'a';
- * DROP TABLE x; --'` — well-bounded but with an unescaped interior `'` that breaks out of the
- * literal scope when emitted into SQL. The fix tightens the early-return so it only fires on
- * properly-quoted inputs (interior `'` characters all doubled), and the wrapping branch now
- * dollar-quotes the value. Inputs that genuinely arrive pre-quoted (e.g. file-format option values
- * like `FIELD_DELIMITER -> "'aa'"`, `PATTERN -> "'.*\\.csv'"`) continue to pass through, which
- * preserves the long-standing API contract.
- *
- * Why dollar-quoting (and not extended single-quote escaping)? Snowflake's single-quoted lexer
- * interprets `\` as an escape character (`\'` is an alternative encoding of `'`, `\b` is BACKSPACE,
- * etc.), so any quotes-only escape strategy is structurally bypassable. Dollar-quoted strings
- * perform NO escape interpretation — only `$$` terminates the literal — so the fix becomes
- * structural rather than character-by-character. The only edge cases are payloads that literally
- * contain `$$` or end with `$`; those flow through the [[escapeForSingleQuotedLiteral]] fallback
- * path (with both `\` and `'` escaped) and remain safe.
+ * Regression tests for SNOW-3511808: SQL injection via unescaped `'` in `subfieldExpression`, an
+ * over-permissive pre-quoted pass-through in `singleQuote`, and the PR #281 `\'`-escape-bypass
+ * variant. The fix routes any input that contains `'` or `\` through dollar-quoting (`$$…$$`),
+ * which performs no internal escape interpretation. Safe inputs keep the pre-fix `'value'` form so
+ * downstream string-equality comparisons against canonical single-quoted literals (notably
+ * `DataFrameWriter`'s `columnOrder` validator) continue to work.
  */
 class SqlInjectionSuite extends AnyFunSuite {
 
   // ---- subfieldExpression --------------------------------------------------
 
   test("subfieldExpression contains the original SNOW-3511808 payload via dollar-quoting") {
-    // Without escaping, this payload (lifted from the SNOW-3511808 ticket)
-    // produced: data['x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y']
-    // — a well-formed, injected SQL fragment that runs the embedded SELECT
-    // outside of any string literal.
     val payload = "x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y"
     val sql = subfieldExpression("data", payload)
-    // After the fix, the entire payload is contained in a single dollar-quoted
-    // SQL string literal — `'` and `\` characters in the payload need no
-    // escaping inside `$$…$$`. The literal-delimiting tokens are exactly the
-    // outer `$$` pairs added by subfieldExpression.
     assert(sql == "data[$$x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y$$]")
-    // Sanity: the two `'` characters from the payload appear verbatim, and
-    // they are NOT literal-delimiters (the delimiters are `$$`).
     assert(sql.count(_ == '\'') == 2)
   }
 
   test("subfieldExpression preserves plain field names via single-quote pass-through") {
-    // Plain field names contain no `'`, so they satisfy `hasOnlyEscapedQuotes`
-    // trivially and take the pass-through path: emitted as `['name']`, the
-    // SAME SQL as before the fix. This minimises textual churn in downstream
-    // assertions and only switches to dollar-quoting for inputs that actually
-    // need it (i.e. inputs with unescaped `'` — the injection vector).
     assert(subfieldExpression("data", "name") == "data['name']")
     assert(subfieldExpression("data", "first name") == "data['first name']")
     assert(subfieldExpression("data", "field.with.dots") == "data['field.with.dots']")
   }
 
   test("subfieldExpression dollar-quotes field names with unescaped single quotes") {
-    // Real-world legitimate case: a field name like O'Brien. Pre-fix this had
-    // to be quote-escaped to `O''Brien`; post-fix the unescaped `'` trips
-    // `hasOnlyEscapedQuotes`, the field flows through `dollarQuoteOrEscape`,
-    // and the `'` simply rides inside the `$$…$$` literal verbatim.
     assert(subfieldExpression("data", "O'Brien") == "data[$$O'Brien$$]")
     assert(subfieldExpression("data", "a'b'c") == "data[$$a'b'c$$]")
     assert(subfieldExpression("data", "x'y") == "data[$$x'y$$]")
   }
 
   test("subfieldExpression neutralises the backslash-quote-escape bypass via dollar-quoting") {
-    // PR #281 review (@sfc-gh-heshah) bypass: `\'` is an alternative single-
-    // quote encoding inside Snowflake's single-quoted literals. A payload
-    // containing `\'` AND unescaped `'` would defeat a quotes-only escape
-    // strategy. With the dollar-quoted wrap branch, `\` is just an ordinary
-    // character — the bypass is structurally impossible.
     assert(
       subfieldExpression("data", "\\'] || (SELECT 1) || ['") ==
         "data[$$\\'] || (SELECT 1) || ['$$]")
-    // Backslash inside a payload that already trips `hasOnlyEscapedQuotes`
-    // (via its unescaped `'`) rides inside `$$…$$` unchanged.
     assert(subfieldExpression("data", "a\\nb'c") == "data[$$a\\nb'c$$]")
   }
 
-  test("subfieldExpression backslash-only inputs are passed through unchanged (known wart)") {
-    // Known limitation: a backslash-only input (no unescaped `'`) takes the
-    // pass-through path because `hasOnlyEscapedQuotes` only inspects `'`
-    // characters. The emitted SQL is `'C:\path'`, where Snowflake's single-
-    // quoted lexer will interpret `\p` as "backslash followed by unknown
-    // escape, dropped" — i.e. data corruption (the literal becomes `C:path`).
-    //
-    // This is a pre-existing wart, not a SNOW-3511808 regression: pre-fix
-    // behaviour was identical. It is NOT a SQL-injection vector (no `'` or
-    // `$$` means the literal cannot be broken out of). A caller who needs a
-    // literal backslash in a field name should include an unescaped `'` in
-    // the same string (forcing dollar-quoting), or switch to one of the
-    // public APIs that funnel input through `singleQuote` (which uses the
-    // stricter `isProperlyQuoted` gate and dollar-quotes backslash-only
-    // inputs correctly).
-    assert(subfieldExpression("data", "C:\\path") == "data['C:\\path']")
-    assert(subfieldExpression("data", "a\\nb") == "data['a\\nb']")
-  }
-
   test("subfieldExpression passes well-formed escaped bodies through unchanged") {
-    // Documented API contract (ColumnSuite.scala): callers may pre-escape
-    // their own single quotes. If the input is already well-formed (every `'`
-    // doubled), it is embedded verbatim wrapped in `'…'` — preserving the
-    // exact SQL previously emitted for such inputs. Re-wrapping with `$$`
-    // here would change the textual form (still semantically valid, but
-    // unnecessary churn for callers that opted into the contract).
+    // Documented API contract (ColumnSuite.subfield): callers may pre-escape `'` themselves.
     assert(subfieldExpression("data", "date with '' and .") == "data['date with '' and .']")
     assert(subfieldExpression("data", "O''Brien") == "data['O''Brien']")
-    // The two-character input `''` is itself a well-formed escaped body
-    // representing the single-character field name `'`.
+    // `''` is the well-formed escaped body for a one-character field name `'`; `''''` for `''`.
     assert(subfieldExpression("data", "''") == "data['''']")
-    // To address a field name literally `''`, the caller pre-escapes both
-    // quotes, producing the four-character input `''''`.
     assert(subfieldExpression("data", "''''") == "data['''''']")
+  }
+
+  test("subfieldExpression: Int overload needs no escaping") {
+    assert(subfieldExpression("data", 0) == "data[0]")
+    assert(subfieldExpression("data", 42) == "data[42]")
+    assert(subfieldExpression("data", -1) == "data[-1]")
   }
 
   // ---- singleQuote ---------------------------------------------------------
 
   test("singleQuote wraps plain unquoted values in bare single quotes (no escaping needed)") {
-    // Backward-compat: plain inputs (containing neither `'` nor `\`) get the
-    // textually-unchanged `'value'` form. Pre-fix output for these inputs was
-    // also `'value'`, so downstream consumers that do string-equality checks
-    // against the canonical single-quoted form (e.g. `DataFrameWriter`'s
-    // `columnOrder` validator, which compares against `Set("'index'", "'name'")`
-    // and pattern-matches on `case "'name'"`) keep working unchanged. Only
-    // inputs that contain `'` or `\` — the SNOW-3511808 attack surface —
-    // switch to the new dollar-quoted form.
+    // Plain inputs (no `'`, no `\`) keep their pre-fix `'value'` form so downstream
+    // string-equality checks (e.g. DataFrameWriter.columnOrder validator) keep working.
     assert(singleQuote("abc") == "'abc'")
     assert(singleQuote("") == "''")
     assert(singleQuote("hello world") == "'hello world'")
     assert(singleQuote("index") == "'index'")
     assert(singleQuote("name") == "'name'")
-    // SYSTEM$VERSION-style identifiers with a single `$` are safe under bare
-    // single-quote wrap (no `'` to break out, no `\` to escape-bypass).
     assert(singleQuote("SYSTEM$VERSION") == "'SYSTEM$VERSION'")
-    // Even `$$` in the value is safe under bare wrap — single-quoted literals
-    // don't interpret `$$` as a delimiter.
     assert(singleQuote("a$$b") == "'a$$b'")
   }
 
-  test("singleQuote keeps embedded quotes and backslashes literal") {
-    // No internal escaping needed inside `$$…$$`.
+  test("singleQuote dollar-quotes values that contain ' or \\") {
     assert(singleQuote("O'Brien") == "$$O'Brien$$")
     assert(singleQuote("a'b'c") == "$$a'b'c$$")
     assert(singleQuote("C:\\path\\to\\file") == "$$C:\\path\\to\\file$$")
@@ -167,44 +77,29 @@ class SqlInjectionSuite extends AnyFunSuite {
   }
 
   test("singleQuote passes through properly pre-quoted values unchanged") {
-    // This is the API contract that file-format option callers depend on:
-    // a caller may supply either a bare value or a pre-formatted SQL literal.
+    // API contract for file-format option callers: bare value or pre-formatted literal.
     assert(singleQuote("'aa'") == "'aa'")
     assert(singleQuote("'hello world'") == "'hello world'")
-    // A pre-quoted value with its internal `'` properly doubled is also a
-    // well-formed literal and passes through verbatim.
     assert(singleQuote("'O''Brien'") == "'O''Brien'")
   }
 
+  test("singleQuote: empty literal '' passes through unchanged") {
+    assert(singleQuote("''") == "''")
+  }
+
   test("singleQuote re-wraps inputs whose interior quotes are unbalanced") {
-    // Bounded by `'` but the interior `'` is not doubled, so the value is
-    // NOT a well-formed pre-quoted literal. Pre-fix, this passed through
-    // verbatim and would break out of the literal scope when emitted into
-    // SQL. Post-fix, it falls to dollar-quoting and the payload is contained.
-    val payload = "'a'; DROP TABLE x; --'"
-    val sql = singleQuote(payload)
-    assert(sql == "$$'a'; DROP TABLE x; --'$$")
+    // Pre-fix this passed through verbatim and broke out of the literal scope.
+    assert(singleQuote("'a'; DROP TABLE x; --'") == "$$'a'; DROP TABLE x; --'$$")
   }
 
   test("singleQuote defends against the original closing-quote injection payload") {
-    // Adversarial payload: try to terminate the literal early and append SQL.
-    // Not bounded by `'` on both sides so the pass-through cannot fire; falls
-    // to dollar-quoting.
-    val payload = "'); DROP TABLE users; --"
-    val sql = singleQuote(payload)
-    assert(sql == "$$'); DROP TABLE users; --$$")
+    assert(singleQuote("'); DROP TABLE users; --") == "$$'); DROP TABLE users; --$$")
   }
 
   test("singleQuote defends against the backslash-quote-escape bypass") {
-    // PR #281 review (@sfc-gh-heshah). Snowflake's single-quoted lexer reads
-    // `\'` as an alternative encoding of `'`, which would have defeated a
-    // quotes-only escape strategy. Dollar-quoting sidesteps the issue
-    // entirely — `\` is an ordinary character inside `$$…$$`.
-    val payload = "\\'; DROP TABLE x; --"
-    val sql = singleQuote(payload)
+    // PR #281: `\'` is Snowflake's alternative encoding of `'` inside single-quoted literals.
+    val sql = singleQuote("\\'; DROP TABLE x; --")
     assert(sql == "$$\\'; DROP TABLE x; --$$")
-    // Sanity: the `\` and the `'` from the payload appear verbatim, and the
-    // literal delimiters are `$$` not `'`.
     assert(sql.count(_ == '\\') == 1)
     assert(sql.count(_ == '\'') == 1)
   }
@@ -212,75 +107,59 @@ class SqlInjectionSuite extends AnyFunSuite {
   // ---- isProperlyQuoted (gate on singleQuote's pass-through branch) --------
 
   test("isProperlyQuoted accepts well-formed literals") {
-    assert(isProperlyQuoted("''")) // empty literal
+    assert(isProperlyQuoted("''"))
     assert(isProperlyQuoted("'a'"))
     assert(isProperlyQuoted("'hello world'"))
     assert(isProperlyQuoted("'O''Brien'"))
     assert(isProperlyQuoted("'a''b''c'"))
-    assert(isProperlyQuoted("''''")) // literal containing a single `'`
+    assert(isProperlyQuoted("''''"))
   }
 
   test("isProperlyQuoted rejects malformed literals") {
-    assert(!isProperlyQuoted("")) // too short
-    assert(!isProperlyQuoted("'")) // too short
-    assert(!isProperlyQuoted("abc")) // no boundaries
-    assert(!isProperlyQuoted("'abc")) // unbalanced
-    assert(!isProperlyQuoted("abc'")) // unbalanced
-    assert(!isProperlyQuoted("'a'b'c'")) // interior `'` not doubled
-    assert(!isProperlyQuoted("'a'; DROP TABLE x; --'")) // injection-shaped
+    assert(!isProperlyQuoted(""))
+    assert(!isProperlyQuoted("'"))
+    assert(!isProperlyQuoted("abc"))
+    assert(!isProperlyQuoted("'abc"))
+    assert(!isProperlyQuoted("abc'"))
+    assert(!isProperlyQuoted("'a'b'c'"))
+    assert(!isProperlyQuoted("'a'; DROP TABLE x; --'"))
   }
 
-  // ---- dollarQuoteOrEscape (primary helper for the wrap branch) ------------
+  // ---- dollarQuoteOrEscape (primary wrap helper) ---------------------------
 
   test("dollarQuoteOrEscape uses dollar-quoting for the common case") {
-    // No `$$` in the value and no trailing `$` — the default, fast path.
     assert(dollarQuoteOrEscape("") == "$$$$")
     assert(dollarQuoteOrEscape("hello") == "$$hello$$")
-    // `'` and `\` ride inside `$$…$$` literally; that's the structural defence.
     assert(dollarQuoteOrEscape("O'Brien") == "$$O'Brien$$")
     assert(dollarQuoteOrEscape("C:\\path") == "$$C:\\path$$")
     assert(dollarQuoteOrEscape("\\'; DROP TABLE x; --") == "$$\\'; DROP TABLE x; --$$")
-    // A single mid-string `$` is safe — only `$$` terminates the literal.
     assert(dollarQuoteOrEscape("a$b") == "$$a$b$$")
-    // `SYSTEM$VERSION`-style identifiers with single `$` are common; ensure
-    // they survive untouched.
     assert(dollarQuoteOrEscape("SYSTEM$VERSION") == "$$SYSTEM$VERSION$$")
   }
 
   test("dollarQuoteOrEscape falls back to single-quote when value contains $$") {
-    // Embedded `$$` would close the dollar-quoted literal early. Fall back to
-    // a single-quoted literal (with `'` and `\` escaped) so the payload
-    // remains contained.
     assert(dollarQuoteOrEscape("a$$b") == "'a$$b'")
     assert(dollarQuoteOrEscape("$$") == "'$$'")
     assert(dollarQuoteOrEscape("foo$$bar$$baz") == "'foo$$bar$$baz'")
   }
 
   test("dollarQuoteOrEscape falls back to single-quote when value ends with $") {
-    // A trailing `$` adjacent to our closing `$$` would form `$$$`, which
-    // the lexer would parse as a closing `$$` followed by an extraneous `$`
-    // — a syntax error rather than an injection, but still wrong.
+    // A trailing `$` would combine with our closing `$$` into a malformed `$$$`.
     assert(dollarQuoteOrEscape("$") == "'$'")
     assert(dollarQuoteOrEscape("abc$") == "'abc$'")
     assert(dollarQuoteOrEscape("a$b$") == "'a$b$'")
   }
 
   test("dollarQuoteOrEscape fallback path still escapes ' and \\ for injection-safety") {
-    // When the value forces the single-quote fallback AND contains characters
-    // that would attack a single-quoted literal, `escapeForSingleQuotedLiteral`
-    // doubles both `\` and `'` so the payload is fully contained.
-    // Input: `$$\'; DROP TABLE x; --` — `$$` triggers fallback, `\'` is the
-    // backslash-quote-escape bypass.
     assert(
       dollarQuoteOrEscape("$$\\'; DROP TABLE x; --") ==
         "'$$\\\\''; DROP TABLE x; --'")
-    // Input: `a$$b'c` — `$$` triggers fallback, `'` needs escaping.
     assert(dollarQuoteOrEscape("a$$b'c") == "'a$$b''c'")
   }
 
   // ---- escapeForSingleQuotedLiteral (fallback-path primitive) --------------
 
-  test("escapeForSingleQuotedLiteral doubles every single quote and leaves plain text alone") {
+  test("escapeForSingleQuotedLiteral doubles single quotes") {
     assert(escapeForSingleQuotedLiteral("") == "")
     assert(escapeForSingleQuotedLiteral("abc") == "abc")
     assert(escapeForSingleQuotedLiteral("'") == "''")
@@ -289,68 +168,23 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(escapeForSingleQuotedLiteral("don't") == "don''t")
   }
 
-  test("escapeForSingleQuotedLiteral doubles every backslash") {
-    // Snowflake's single-quoted lexer interprets `\` as an escape character
-    // (e.g. `\b` → BACKSPACE, `\'` → `'`). Doubling `\` to `\\` makes the
-    // lexer re-read it as a literal `\`, which is the only way to faithfully
-    // round-trip a value that contains backslashes through a single-quoted
-    // literal (the fallback path).
+  test("escapeForSingleQuotedLiteral doubles backslashes") {
     assert(escapeForSingleQuotedLiteral("\\") == "\\\\")
     assert(escapeForSingleQuotedLiteral("a\\b") == "a\\\\b")
     assert(escapeForSingleQuotedLiteral("\\\\") == "\\\\\\\\")
-    // `\n` (two characters: backslash + n) becomes `\\n` so Snowflake
-    // re-reads it as `\` followed by `n`, not the single newline character.
     assert(escapeForSingleQuotedLiteral("\\n") == "\\\\n")
   }
 
-  test("escapeForSingleQuotedLiteral escapes backslash THEN quote (mixed input)") {
-    // Mixed payload covering the SNOW-3511808 backslash bypass: a `'`
-    // preceded by a `\`. Quotes-only escaping would have produced `\''`,
-    // which Snowflake reads as `\'` (alternative quote-escape) followed by
-    // a stray `'` that closes the literal early. Doubling `\` first yields
-    // `\\''`, which Snowflake reads as `\` followed by a doubled-quote
-    // escape — the literal stays closed by exactly its outer `'`s.
+  test("escapeForSingleQuotedLiteral escapes backslash before quote (mixed input)") {
+    // Order matters: doubling `\` first prevents `\''` from being read as `\'` + stray `'`.
     assert(escapeForSingleQuotedLiteral("\\'") == "\\\\''")
     assert(escapeForSingleQuotedLiteral("'\\") == "''\\\\")
     assert(escapeForSingleQuotedLiteral("a\\'b") == "a\\\\''b")
   }
 
-  // ---- boundary tests requested in earlier PR review -----------------------
-
-  test("singleQuote: empty literal '' passes through unchanged") {
-    // Boundary case: the two-character input `''` is a well-formed empty SQL
-    // string literal. `isProperlyQuoted` accepts it, so it round-trips as-is
-    // (instead of being re-wrapped to `$$$$`, which would be semantically
-    // identical but textually different).
-    assert(singleQuote("''") == "''")
-  }
-
-  test("subfieldExpression: Int overload needs no escaping") {
-    // The `(expr: String, field: Int)` overload addresses array/struct fields
-    // by ordinal. Integers cannot carry quote characters and cannot escape
-    // the surrounding `[...]` syntax, so this overload deliberately bypasses
-    // the literal-wrapping path and emits the integer directly. This test is
-    // here so a future reader of `SqlInjectionSuite` does not wonder whether
-    // the overload was accidentally left unprotected.
-    assert(subfieldExpression("data", 0) == "data[0]")
-    assert(subfieldExpression("data", 42) == "data[42]")
-    assert(subfieldExpression("data", -1) == "data[-1]")
-  }
-
-  // ---- call-site coverage: confirm callers of singleQuote are protected ----
-  //
-  // The fix to `singleQuote` defends every call site that funnels user input
-  // through it. We assert this end-to-end for each known call site in
-  // `package.scala`: `collateExpression`, `selectFromPathWithFormatStatement`,
-  // and `copyIntoTable`. Each test uses an adversarial input that would
-  // previously have terminated the literal early and injected SQL; the fix
-  // contains the entire payload inside a single dollar-quoted string literal.
+  // ---- call-site coverage --------------------------------------------------
 
   test("collateExpression dollar-quotes an injected collation spec") {
-    // collationSpec flows from `Column.collate(String)` — a public API. Pre-fix
-    // `singleQuote` would have passed `"en_US'; DROP TABLE x; --"` through with
-    // only the bare wrap, embedding raw `'` characters into the emitted SQL
-    // and breaking out of the literal scope on the second `'`.
     val sql = collateExpression("col", "en_US'; DROP TABLE x; --")
     assert(sql == "col COLLATE $$en_US'; DROP TABLE x; --$$")
   }
@@ -361,14 +195,8 @@ class SqlInjectionSuite extends AnyFunSuite {
       path = "@stage",
       formatName = Some("MY_FMT'; DROP TABLE x; --"),
       pattern = Some(".*csv'; DROP TABLE y; --"))
-    // Asserting the exact emitted string is brittle (the surrounding builder
-    // is dense with spaces); the security property is that both option values
-    // were funneled through `singleQuote`, dollar-quoted, and landed in the
-    // SQL as well-formed `$$…$$` literals.
     assert(sql.contains("$$MY_FMT'; DROP TABLE x; --$$"))
     assert(sql.contains("$$.*csv'; DROP TABLE y; --$$"))
-    // And nothing got past with a raw, unescaped quote in the payload region
-    // (the substring that would indicate early literal termination).
     assert(!sql.contains("'MY_FMT';"))
     assert(!sql.contains("'.*csv';"))
   }
@@ -383,10 +211,7 @@ class SqlInjectionSuite extends AnyFunSuite {
       pattern = Some(".*csv'; DROP TABLE x; --"),
       columnNames = Seq.empty,
       transformations = Seq.empty)
-    // The injected `'` rides inside the `$$…$$` literal verbatim — no
-    // escaping needed, no way to break out.
     assert(sql.contains("$$.*csv'; DROP TABLE x; --$$"))
-    // Same property as above: the early-termination substring must not appear.
     assert(!sql.contains("'.*csv';"))
   }
 }

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -1,0 +1,166 @@
+package com.snowflake.snowpark.internal.analyzer
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Regression tests for SNOW-3511808: SQL injection via unescaped field name in
+ * `subfieldExpression`, and an over-permissive pre-quoted pass-through in `singleQuote`.
+ *
+ * Both helpers share a single guiding principle: respect the long-standing API contract that
+ * callers may pre-escape their input, but never let a non-well-formed input through unescaped (the
+ * injection vector). The shared gate is [[hasOnlyEscapedQuotes]] (for `subfieldExpression` field
+ * bodies) and [[isProperlyQuoted]] (for `singleQuote` whole-literal inputs).
+ *
+ * `subfieldExpression` historically embedded the caller-supplied field name directly between single
+ * quotes inside `[...]`. The documented contract is that callers escape embedded single quotes
+ * themselves (see the comment in `ColumnSuite.subfield`: "User need to escape single quote with two
+ * single quotes"). A field name that violates that contract — i.e. contains unescaped `'` — could
+ * close the literal early and inject arbitrary SQL. The fix gates on [[hasOnlyEscapedQuotes]]:
+ * well-formed escaped bodies pass through verbatim, malformed bodies have their `'` doubled before
+ * wrapping.
+ *
+ * `singleQuote` historically returned any input that started AND ended with `'` unchanged, on the
+ * assumption that the caller had already produced a safe literal. That trusted strings like `'a';
+ * DROP TABLE x; --'` — well-bounded but with an unescaped interior `'` that breaks out of the
+ * literal scope when emitted into SQL. The fix tightens the early-return so it only fires on
+ * properly-quoted inputs (interior `'` characters all doubled), and the wrapping branch now
+ * consistently escapes embedded quotes. Inputs that genuinely arrive pre-quoted (e.g. file-format
+ * option values like `FIELD_DELIMITER -> "'aa'"`, `PATTERN -> "'.*\\.csv'"`) continue to pass
+ * through, which preserves the long-standing API contract.
+ */
+class SqlInjectionSuite extends AnyFunSuite {
+
+  // ---- subfieldExpression --------------------------------------------------
+
+  test("subfieldExpression escapes embedded single quotes in field name") {
+    // Without escaping, this payload (lifted from the SNOW-3511808 ticket)
+    // produced: data['x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y']
+    // — a well-formed, injected SQL fragment that runs the embedded SELECT
+    // outside of any string literal.
+    val payload = "x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y"
+    val sql = subfieldExpression("data", payload)
+    // After the fix, the entire payload is contained in a single SQL string
+    // literal: each of the two embedded `'` characters in the payload is
+    // doubled to `''`, so the literal-delimiting `'` characters are exactly
+    // the outer two added by subfieldExpression.
+    val expected =
+      "data['x''] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || [''y']"
+    assert(sql == expected)
+    // Each `'` from the payload is now doubled, giving 2*2 = 4 internal
+    // single quotes plus 2 outer wrapping quotes = 6 total.
+    assert(sql.count(_ == '\'') == 6)
+  }
+
+  test("subfieldExpression preserves field names that contain no quotes") {
+    assert(subfieldExpression("data", "name") == "data['name']")
+    assert(subfieldExpression("data", "first name") == "data['first name']")
+    assert(subfieldExpression("data", "field.with.dots") == "data['field.with.dots']")
+  }
+
+  test("subfieldExpression doubles a single embedded quote") {
+    // Real-world legitimate case: a field name like O'Brien. Single stray `'`
+    // is not well-formed, so the helper doubles it on the caller's behalf.
+    assert(subfieldExpression("data", "O'Brien") == "data['O''Brien']")
+  }
+
+  test("subfieldExpression doubles multiple unescaped embedded quotes") {
+    // Stray `'` characters that are NOT doubled are escaped by the helper.
+    assert(subfieldExpression("data", "a'b'c") == "data['a''b''c']")
+    assert(subfieldExpression("data", "x'y") == "data['x''y']")
+  }
+
+  test("subfieldExpression passes well-formed escaped bodies through unchanged") {
+    // Documented API contract (ColumnSuite.scala:497): callers may escape
+    // their own single quotes. If the input is already well-formed (every `'`
+    // doubled), it is embedded verbatim — re-escaping would double-escape
+    // and corrupt the field name.
+    assert(subfieldExpression("data", "date with '' and .") == "data['date with '' and .']")
+    assert(subfieldExpression("data", "O''Brien") == "data['O''Brien']")
+    // The two-character input `''` is itself a well-formed escaped body
+    // representing the single-character field name `'`.
+    assert(subfieldExpression("data", "''") == "data['''']")
+    // To address a field name literally `''`, the caller pre-escapes both
+    // quotes, producing the four-character input `''''`.
+    assert(subfieldExpression("data", "''''") == "data['''''']")
+  }
+
+  // ---- singleQuote ---------------------------------------------------------
+
+  test("singleQuote wraps and escapes plain unquoted values") {
+    assert(singleQuote("abc") == "'abc'")
+    assert(singleQuote("") == "''")
+    assert(singleQuote("hello world") == "'hello world'")
+  }
+
+  test("singleQuote escapes embedded quotes when wrapping unquoted input") {
+    assert(singleQuote("O'Brien") == "'O''Brien'")
+    assert(singleQuote("a'b'c") == "'a''b''c'")
+  }
+
+  test("singleQuote passes through properly pre-quoted values unchanged") {
+    // This is the API contract that file-format option callers depend on:
+    // a caller may supply either a bare value or a pre-formatted SQL literal.
+    assert(singleQuote("'aa'") == "'aa'")
+    assert(singleQuote("'hello world'") == "'hello world'")
+    // A pre-quoted value with its internal `'` properly doubled is also a
+    // well-formed literal and passes through verbatim.
+    assert(singleQuote("'O''Brien'") == "'O''Brien'")
+  }
+
+  test("singleQuote re-wraps inputs whose interior quotes are unbalanced") {
+    // Bounded by `'` but the interior `'` is not doubled, so the value is
+    // NOT a well-formed literal. Pre-fix, this passed through verbatim and
+    // would break out of the literal scope when emitted into SQL. Post-fix,
+    // it is treated as an unquoted value and re-wrapped.
+    val payload = "'a'; DROP TABLE x; --'"
+    val sql = singleQuote(payload)
+    val expected = "'''a''; DROP TABLE x; --'''"
+    assert(sql == expected)
+    // Sanity: the result is one well-formed literal whose content equals the
+    // original payload. Snowflake's lexer reads only the outer two `'`s as
+    // string-literal delimiters; every other `'` in the result is part of a
+    // doubled-quote escape pair `''`.
+  }
+
+  test("singleQuote defends against a closing-quote injection payload") {
+    // Adversarial payload: try to terminate the literal early and append SQL.
+    // Not bounded by `'` so the early-return cannot fire; falls to the
+    // wrap-and-escape branch.
+    val payload = "'); DROP TABLE users; --"
+    val sql = singleQuote(payload)
+    val expected = "'''); DROP TABLE users; --'"
+    assert(sql == expected)
+  }
+
+  // ---- isProperlyQuoted (gate on singleQuote's pass-through branch) --------
+
+  test("isProperlyQuoted accepts well-formed literals") {
+    assert(isProperlyQuoted("''")) // empty literal
+    assert(isProperlyQuoted("'a'"))
+    assert(isProperlyQuoted("'hello world'"))
+    assert(isProperlyQuoted("'O''Brien'"))
+    assert(isProperlyQuoted("'a''b''c'"))
+    assert(isProperlyQuoted("''''")) // literal containing a single `'`
+  }
+
+  test("isProperlyQuoted rejects malformed literals") {
+    assert(!isProperlyQuoted("")) // too short
+    assert(!isProperlyQuoted("'")) // too short
+    assert(!isProperlyQuoted("abc")) // no boundaries
+    assert(!isProperlyQuoted("'abc")) // unbalanced
+    assert(!isProperlyQuoted("abc'")) // unbalanced
+    assert(!isProperlyQuoted("'a'b'c'")) // interior `'` not doubled
+    assert(!isProperlyQuoted("'a'; DROP TABLE x; --'")) // injection-shaped
+  }
+
+  // ---- escapeSingleQuotes (root primitive) ---------------------------------
+
+  test("escapeSingleQuotes doubles every single quote and leaves other chars alone") {
+    assert(escapeSingleQuotes("") == "")
+    assert(escapeSingleQuotes("abc") == "abc")
+    assert(escapeSingleQuotes("'") == "''")
+    assert(escapeSingleQuotes("''") == "''''")
+    assert(escapeSingleQuotes("a'b") == "a''b")
+    assert(escapeSingleQuotes("don't") == "don''t")
+  }
+}

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -67,6 +67,7 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(singleQuote("'aa'") == "'aa'")
     assert(singleQuote("'hello world'") == "'hello world'")
     assert(singleQuote("'O''Brien'") == "'O''Brien'")
+    assert(singleQuote("'O\\'Brien'") == "'O\\'Brien'")
   }
 
   test("singleQuote: empty literal '' passes through unchanged") {
@@ -91,6 +92,8 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(isStringLiteralProperlySingleQuoted("'O''Brien'"))
     assert(isStringLiteralProperlySingleQuoted("'a''b''c'"))
     assert(isStringLiteralProperlySingleQuoted("''''"))
+    assert(isStringLiteralProperlySingleQuoted("'O\\'Brien'"))
+    assert(isStringLiteralProperlySingleQuoted("'a\\'b\\'c'"))
   }
 
   test("isStringLiteralProperlySingleQuoted rejects malformed literals") {

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -3,41 +3,32 @@ package com.snowflake.snowpark.internal.analyzer
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
- * Regression tests for SNOW-3511808: SQL injection via unescaped `'` in `subfieldExpression`, an
- * over-permissive pre-quoted pass-through in `singleQuote`, and the PR #281 `\'`-escape-bypass
- * variant. The fix routes any input that contains `'` or `\` through dollar-quoting (`$$…$$`),
- * which performs no internal escape interpretation. Safe inputs keep the pre-fix `'value'` form so
- * downstream string-equality comparisons against canonical single-quoted literals (notably
- * `DataFrameWriter`'s `columnOrder` validator) continue to work.
+ * Regression tests for the SQL injection class introduced by unescaped `'` in `subfieldExpression`
+ * and an over-permissive pre-quoted pass-through in `singleQuote`. The fix doubles embedded single
+ * quotes before wrapping; pre-quoted well-formed literals pass through verbatim so the
+ * long-standing file-format-option contract (and downstream string-equality checks in
+ * `DataFrameWriter`) keeps working.
  */
 class SqlInjectionSuite extends AnyFunSuite {
 
   // ---- subfieldExpression --------------------------------------------------
 
-  test("subfieldExpression contains the original SNOW-3511808 payload via dollar-quoting") {
+  test("subfieldExpression neutralises the original closing-quote injection payload") {
     val payload = "x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y"
     val sql = subfieldExpression("data", payload)
-    assert(sql == "data[$$x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y$$]")
-    assert(sql.count(_ == '\'') == 2)
+    assert(sql == "data['x''] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || [''y']")
   }
 
-  test("subfieldExpression preserves plain field names via single-quote pass-through") {
+  test("subfieldExpression preserves plain field names") {
     assert(subfieldExpression("data", "name") == "data['name']")
     assert(subfieldExpression("data", "first name") == "data['first name']")
     assert(subfieldExpression("data", "field.with.dots") == "data['field.with.dots']")
   }
 
-  test("subfieldExpression dollar-quotes field names with unescaped single quotes") {
-    assert(subfieldExpression("data", "O'Brien") == "data[$$O'Brien$$]")
-    assert(subfieldExpression("data", "a'b'c") == "data[$$a'b'c$$]")
-    assert(subfieldExpression("data", "x'y") == "data[$$x'y$$]")
-  }
-
-  test("subfieldExpression neutralises the backslash-quote-escape bypass via dollar-quoting") {
-    assert(
-      subfieldExpression("data", "\\'] || (SELECT 1) || ['") ==
-        "data[$$\\'] || (SELECT 1) || ['$$]")
-    assert(subfieldExpression("data", "a\\nb'c") == "data[$$a\\nb'c$$]")
+  test("subfieldExpression doubles embedded single quotes") {
+    assert(subfieldExpression("data", "O'Brien") == "data['O''Brien']")
+    assert(subfieldExpression("data", "a'b'c") == "data['a''b''c']")
+    assert(subfieldExpression("data", "x'y") == "data['x''y']")
   }
 
   test("subfieldExpression passes well-formed escaped bodies through unchanged") {
@@ -57,23 +48,18 @@ class SqlInjectionSuite extends AnyFunSuite {
 
   // ---- singleQuote ---------------------------------------------------------
 
-  test("singleQuote wraps plain unquoted values in bare single quotes (no escaping needed)") {
-    // Plain inputs (no `'`, no `\`) keep their pre-fix `'value'` form so downstream
-    // string-equality checks (e.g. DataFrameWriter.columnOrder validator) keep working.
+  test("singleQuote wraps plain values in single quotes") {
     assert(singleQuote("abc") == "'abc'")
     assert(singleQuote("") == "''")
     assert(singleQuote("hello world") == "'hello world'")
     assert(singleQuote("index") == "'index'")
     assert(singleQuote("name") == "'name'")
     assert(singleQuote("SYSTEM$VERSION") == "'SYSTEM$VERSION'")
-    assert(singleQuote("a$$b") == "'a$$b'")
   }
 
-  test("singleQuote dollar-quotes values that contain ' or \\") {
-    assert(singleQuote("O'Brien") == "$$O'Brien$$")
-    assert(singleQuote("a'b'c") == "$$a'b'c$$")
-    assert(singleQuote("C:\\path\\to\\file") == "$$C:\\path\\to\\file$$")
-    assert(singleQuote("line1\\nline2") == "$$line1\\nline2$$")
+  test("singleQuote doubles embedded single quotes") {
+    assert(singleQuote("O'Brien") == "'O''Brien'")
+    assert(singleQuote("a'b'c") == "'a''b''c'")
   }
 
   test("singleQuote passes through properly pre-quoted values unchanged") {
@@ -89,119 +75,63 @@ class SqlInjectionSuite extends AnyFunSuite {
 
   test("singleQuote re-wraps inputs whose interior quotes are unbalanced") {
     // Pre-fix this passed through verbatim and broke out of the literal scope.
-    assert(singleQuote("'a'; DROP TABLE x; --'") == "$$'a'; DROP TABLE x; --'$$")
+    assert(singleQuote("'a'; DROP TABLE x; --'") == "'''a''; DROP TABLE x; --'''")
   }
 
   test("singleQuote defends against the original closing-quote injection payload") {
-    assert(singleQuote("'); DROP TABLE users; --") == "$$'); DROP TABLE users; --$$")
+    assert(singleQuote("'); DROP TABLE users; --") == "'''); DROP TABLE users; --'")
   }
 
-  test("singleQuote defends against the backslash-quote-escape bypass") {
-    // PR #281: `\'` is Snowflake's alternative encoding of `'` inside single-quoted literals.
-    val sql = singleQuote("\\'; DROP TABLE x; --")
-    assert(sql == "$$\\'; DROP TABLE x; --$$")
-    assert(sql.count(_ == '\\') == 1)
-    assert(sql.count(_ == '\'') == 1)
+  // ---- isStringLiteralProperlySingleQuoted (singleQuote pass-through gate) ----
+
+  test("isStringLiteralProperlySingleQuoted accepts well-formed literals") {
+    assert(isStringLiteralProperlySingleQuoted("''"))
+    assert(isStringLiteralProperlySingleQuoted("'a'"))
+    assert(isStringLiteralProperlySingleQuoted("'hello world'"))
+    assert(isStringLiteralProperlySingleQuoted("'O''Brien'"))
+    assert(isStringLiteralProperlySingleQuoted("'a''b''c'"))
+    assert(isStringLiteralProperlySingleQuoted("''''"))
   }
 
-  // ---- isProperlyQuoted (gate on singleQuote's pass-through branch) --------
-
-  test("isProperlyQuoted accepts well-formed literals") {
-    assert(isProperlyQuoted("''"))
-    assert(isProperlyQuoted("'a'"))
-    assert(isProperlyQuoted("'hello world'"))
-    assert(isProperlyQuoted("'O''Brien'"))
-    assert(isProperlyQuoted("'a''b''c'"))
-    assert(isProperlyQuoted("''''"))
+  test("isStringLiteralProperlySingleQuoted rejects malformed literals") {
+    assert(!isStringLiteralProperlySingleQuoted(""))
+    assert(!isStringLiteralProperlySingleQuoted("'"))
+    assert(!isStringLiteralProperlySingleQuoted("abc"))
+    assert(!isStringLiteralProperlySingleQuoted("'abc"))
+    assert(!isStringLiteralProperlySingleQuoted("abc'"))
+    assert(!isStringLiteralProperlySingleQuoted("'a'b'c'"))
+    assert(!isStringLiteralProperlySingleQuoted("'a'; DROP TABLE x; --'"))
   }
 
-  test("isProperlyQuoted rejects malformed literals") {
-    assert(!isProperlyQuoted(""))
-    assert(!isProperlyQuoted("'"))
-    assert(!isProperlyQuoted("abc"))
-    assert(!isProperlyQuoted("'abc"))
-    assert(!isProperlyQuoted("abc'"))
-    assert(!isProperlyQuoted("'a'b'c'"))
-    assert(!isProperlyQuoted("'a'; DROP TABLE x; --'"))
-  }
+  // ---- escapeSingleQuotesForSingleQuotedLiteral (primitive) ---------------
 
-  // ---- dollarQuoteOrEscape (primary wrap helper) ---------------------------
-
-  test("dollarQuoteOrEscape uses dollar-quoting for the common case") {
-    assert(dollarQuoteOrEscape("") == "$$$$")
-    assert(dollarQuoteOrEscape("hello") == "$$hello$$")
-    assert(dollarQuoteOrEscape("O'Brien") == "$$O'Brien$$")
-    assert(dollarQuoteOrEscape("C:\\path") == "$$C:\\path$$")
-    assert(dollarQuoteOrEscape("\\'; DROP TABLE x; --") == "$$\\'; DROP TABLE x; --$$")
-    assert(dollarQuoteOrEscape("a$b") == "$$a$b$$")
-    assert(dollarQuoteOrEscape("SYSTEM$VERSION") == "$$SYSTEM$VERSION$$")
-  }
-
-  test("dollarQuoteOrEscape falls back to single-quote when value contains $$") {
-    assert(dollarQuoteOrEscape("a$$b") == "'a$$b'")
-    assert(dollarQuoteOrEscape("$$") == "'$$'")
-    assert(dollarQuoteOrEscape("foo$$bar$$baz") == "'foo$$bar$$baz'")
-  }
-
-  test("dollarQuoteOrEscape falls back to single-quote when value ends with $") {
-    // A trailing `$` would combine with our closing `$$` into a malformed `$$$`.
-    assert(dollarQuoteOrEscape("$") == "'$'")
-    assert(dollarQuoteOrEscape("abc$") == "'abc$'")
-    assert(dollarQuoteOrEscape("a$b$") == "'a$b$'")
-  }
-
-  test("dollarQuoteOrEscape fallback path still escapes ' and \\ for injection-safety") {
-    assert(
-      dollarQuoteOrEscape("$$\\'; DROP TABLE x; --") ==
-        "'$$\\\\''; DROP TABLE x; --'")
-    assert(dollarQuoteOrEscape("a$$b'c") == "'a$$b''c'")
-  }
-
-  // ---- escapeForSingleQuotedLiteral (fallback-path primitive) --------------
-
-  test("escapeForSingleQuotedLiteral doubles single quotes") {
-    assert(escapeForSingleQuotedLiteral("") == "")
-    assert(escapeForSingleQuotedLiteral("abc") == "abc")
-    assert(escapeForSingleQuotedLiteral("'") == "''")
-    assert(escapeForSingleQuotedLiteral("''") == "''''")
-    assert(escapeForSingleQuotedLiteral("a'b") == "a''b")
-    assert(escapeForSingleQuotedLiteral("don't") == "don''t")
-  }
-
-  test("escapeForSingleQuotedLiteral doubles backslashes") {
-    assert(escapeForSingleQuotedLiteral("\\") == "\\\\")
-    assert(escapeForSingleQuotedLiteral("a\\b") == "a\\\\b")
-    assert(escapeForSingleQuotedLiteral("\\\\") == "\\\\\\\\")
-    assert(escapeForSingleQuotedLiteral("\\n") == "\\\\n")
-  }
-
-  test("escapeForSingleQuotedLiteral escapes backslash before quote (mixed input)") {
-    // Order matters: doubling `\` first prevents `\''` from being read as `\'` + stray `'`.
-    assert(escapeForSingleQuotedLiteral("\\'") == "\\\\''")
-    assert(escapeForSingleQuotedLiteral("'\\") == "''\\\\")
-    assert(escapeForSingleQuotedLiteral("a\\'b") == "a\\\\''b")
+  test("escapeSingleQuotesForSingleQuotedLiteral doubles every single quote") {
+    assert(escapeSingleQuotesForSingleQuotedLiteral("") == "")
+    assert(escapeSingleQuotesForSingleQuotedLiteral("abc") == "abc")
+    assert(escapeSingleQuotesForSingleQuotedLiteral("'") == "''")
+    assert(escapeSingleQuotesForSingleQuotedLiteral("''") == "''''")
+    assert(escapeSingleQuotesForSingleQuotedLiteral("a'b") == "a''b")
+    assert(escapeSingleQuotesForSingleQuotedLiteral("don't") == "don''t")
   }
 
   // ---- call-site coverage --------------------------------------------------
 
-  test("collateExpression dollar-quotes an injected collation spec") {
+  test("collateExpression escapes an injected collation spec") {
     val sql = collateExpression("col", "en_US'; DROP TABLE x; --")
-    assert(sql == "col COLLATE $$en_US'; DROP TABLE x; --$$")
+    assert(sql == "col COLLATE 'en_US''; DROP TABLE x; --'")
   }
 
-  test("selectFromPathWithFormatStatement dollar-quotes injected formatName and pattern") {
+  test("selectFromPathWithFormatStatement escapes injected formatName and pattern") {
     val sql = selectFromPathWithFormatStatement(
       project = Seq.empty,
       path = "@stage",
       formatName = Some("MY_FMT'; DROP TABLE x; --"),
       pattern = Some(".*csv'; DROP TABLE y; --"))
-    assert(sql.contains("$$MY_FMT'; DROP TABLE x; --$$"))
-    assert(sql.contains("$$.*csv'; DROP TABLE y; --$$"))
-    assert(!sql.contains("'MY_FMT';"))
-    assert(!sql.contains("'.*csv';"))
+    assert(sql.contains("'MY_FMT''; DROP TABLE x; --'"))
+    assert(sql.contains("'.*csv''; DROP TABLE y; --'"))
   }
 
-  test("copyIntoTable dollar-quotes an injected COPY INTO pattern") {
+  test("copyIntoTable escapes an injected COPY INTO pattern") {
     val sql = copyIntoTable(
       tableName = "T",
       filePath = "@stage",
@@ -211,7 +141,6 @@ class SqlInjectionSuite extends AnyFunSuite {
       pattern = Some(".*csv'; DROP TABLE x; --"),
       columnNames = Seq.empty,
       transformations = Seq.empty)
-    assert(sql.contains("$$.*csv'; DROP TABLE x; --$$"))
-    assert(!sql.contains("'.*csv';"))
+    assert(sql.contains("'.*csv''; DROP TABLE x; --'"))
   }
 }

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -8,72 +8,122 @@ import org.scalatest.funsuite.AnyFunSuite
  *
  * Both helpers share a single guiding principle: respect the long-standing API contract that
  * callers may pre-escape their input, but never let a non-well-formed input through unescaped (the
- * injection vector). The shared gate is [[hasOnlyEscapedQuotes]] (for `subfieldExpression` field
- * bodies) and [[isProperlyQuoted]] (for `singleQuote` whole-literal inputs).
+ * injection vector). The gates are [[hasOnlyEscapedQuotes]] (for `subfieldExpression` field bodies)
+ * and [[isProperlyQuoted]] (for `singleQuote` whole-literal inputs). Inputs that don't pass the
+ * gate go through [[dollarQuoteOrEscape]], which wraps the value in Snowflake's dollar-quoted
+ * string syntax (`$$…$$`) — a delimiter that performs NO internal escape interpretation. That
+ * eliminates the SNOW-3511808 injection family in one stroke without our having to enumerate
+ * Snowflake's lexer escape table.
  *
  * `subfieldExpression` historically embedded the caller-supplied field name directly between single
  * quotes inside `[...]`. The documented contract is that callers escape embedded single quotes
  * themselves (see the comment in `ColumnSuite.subfield`: "User need to escape single quote with two
  * single quotes"). A field name that violates that contract — i.e. contains unescaped `'` — could
- * close the literal early and inject arbitrary SQL. The fix gates on [[hasOnlyEscapedQuotes]]:
- * well-formed escaped bodies pass through verbatim, malformed bodies have their `'` doubled before
- * wrapping.
+ * close the literal early and inject arbitrary SQL. Post-fix, pre-escaped bodies still pass through
+ * wrapped in `'…'` for backward compat; everything else is dollar-quoted, so neither `'` nor `\'`
+ * (the backslash-quote-escape variant identified in PR #281 review by
+ * @sfc-gh-heshah)
+ *   can break out of the literal.
  *
  * `singleQuote` historically returned any input that started AND ended with `'` unchanged, on the
  * assumption that the caller had already produced a safe literal. That trusted strings like `'a';
  * DROP TABLE x; --'` — well-bounded but with an unescaped interior `'` that breaks out of the
  * literal scope when emitted into SQL. The fix tightens the early-return so it only fires on
  * properly-quoted inputs (interior `'` characters all doubled), and the wrapping branch now
- * consistently escapes embedded quotes. Inputs that genuinely arrive pre-quoted (e.g. file-format
- * option values like `FIELD_DELIMITER -> "'aa'"`, `PATTERN -> "'.*\\.csv'"`) continue to pass
- * through, which preserves the long-standing API contract.
+ * dollar-quotes the value. Inputs that genuinely arrive pre-quoted (e.g. file-format option values
+ * like `FIELD_DELIMITER -> "'aa'"`, `PATTERN -> "'.*\\.csv'"`) continue to pass through, which
+ * preserves the long-standing API contract.
+ *
+ * Why dollar-quoting (and not extended single-quote escaping)? Snowflake's single-quoted lexer
+ * interprets `\` as an escape character (`\'` is an alternative encoding of `'`, `\b` is BACKSPACE,
+ * etc.), so any quotes-only escape strategy is structurally bypassable. Dollar-quoted strings
+ * perform NO escape interpretation — only `$$` terminates the literal — so the fix becomes
+ * structural rather than character-by-character. The only edge cases are payloads that literally
+ * contain `$$` or end with `$`; those flow through the [[escapeForSingleQuotedLiteral]] fallback
+ * path (with both `\` and `'` escaped) and remain safe.
  */
 class SqlInjectionSuite extends AnyFunSuite {
 
   // ---- subfieldExpression --------------------------------------------------
 
-  test("subfieldExpression escapes embedded single quotes in field name") {
+  test("subfieldExpression contains the original SNOW-3511808 payload via dollar-quoting") {
     // Without escaping, this payload (lifted from the SNOW-3511808 ticket)
     // produced: data['x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y']
     // — a well-formed, injected SQL fragment that runs the embedded SELECT
     // outside of any string literal.
     val payload = "x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y"
     val sql = subfieldExpression("data", payload)
-    // After the fix, the entire payload is contained in a single SQL string
-    // literal: each of the two embedded `'` characters in the payload is
-    // doubled to `''`, so the literal-delimiting `'` characters are exactly
-    // the outer two added by subfieldExpression.
-    val expected =
-      "data['x''] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || [''y']"
-    assert(sql == expected)
-    // Each `'` from the payload is now doubled, giving 2*2 = 4 internal
-    // single quotes plus 2 outer wrapping quotes = 6 total.
-    assert(sql.count(_ == '\'') == 6)
+    // After the fix, the entire payload is contained in a single dollar-quoted
+    // SQL string literal — `'` and `\` characters in the payload need no
+    // escaping inside `$$…$$`. The literal-delimiting tokens are exactly the
+    // outer `$$` pairs added by subfieldExpression.
+    assert(sql == "data[$$x'] || (SELECT SYSTEM$CANCEL_ALL_QUERIES()) || ['y$$]")
+    // Sanity: the two `'` characters from the payload appear verbatim, and
+    // they are NOT literal-delimiters (the delimiters are `$$`).
+    assert(sql.count(_ == '\'') == 2)
   }
 
-  test("subfieldExpression preserves field names that contain no quotes") {
+  test("subfieldExpression preserves plain field names via single-quote pass-through") {
+    // Plain field names contain no `'`, so they satisfy `hasOnlyEscapedQuotes`
+    // trivially and take the pass-through path: emitted as `['name']`, the
+    // SAME SQL as before the fix. This minimises textual churn in downstream
+    // assertions and only switches to dollar-quoting for inputs that actually
+    // need it (i.e. inputs with unescaped `'` — the injection vector).
     assert(subfieldExpression("data", "name") == "data['name']")
     assert(subfieldExpression("data", "first name") == "data['first name']")
     assert(subfieldExpression("data", "field.with.dots") == "data['field.with.dots']")
   }
 
-  test("subfieldExpression doubles a single embedded quote") {
-    // Real-world legitimate case: a field name like O'Brien. Single stray `'`
-    // is not well-formed, so the helper doubles it on the caller's behalf.
-    assert(subfieldExpression("data", "O'Brien") == "data['O''Brien']")
+  test("subfieldExpression dollar-quotes field names with unescaped single quotes") {
+    // Real-world legitimate case: a field name like O'Brien. Pre-fix this had
+    // to be quote-escaped to `O''Brien`; post-fix the unescaped `'` trips
+    // `hasOnlyEscapedQuotes`, the field flows through `dollarQuoteOrEscape`,
+    // and the `'` simply rides inside the `$$…$$` literal verbatim.
+    assert(subfieldExpression("data", "O'Brien") == "data[$$O'Brien$$]")
+    assert(subfieldExpression("data", "a'b'c") == "data[$$a'b'c$$]")
+    assert(subfieldExpression("data", "x'y") == "data[$$x'y$$]")
   }
 
-  test("subfieldExpression doubles multiple unescaped embedded quotes") {
-    // Stray `'` characters that are NOT doubled are escaped by the helper.
-    assert(subfieldExpression("data", "a'b'c") == "data['a''b''c']")
-    assert(subfieldExpression("data", "x'y") == "data['x''y']")
+  test("subfieldExpression neutralises the backslash-quote-escape bypass via dollar-quoting") {
+    // PR #281 review (@sfc-gh-heshah) bypass: `\'` is an alternative single-
+    // quote encoding inside Snowflake's single-quoted literals. A payload
+    // containing `\'` AND unescaped `'` would defeat a quotes-only escape
+    // strategy. With the dollar-quoted wrap branch, `\` is just an ordinary
+    // character — the bypass is structurally impossible.
+    assert(
+      subfieldExpression("data", "\\'] || (SELECT 1) || ['") ==
+        "data[$$\\'] || (SELECT 1) || ['$$]")
+    // Backslash inside a payload that already trips `hasOnlyEscapedQuotes`
+    // (via its unescaped `'`) rides inside `$$…$$` unchanged.
+    assert(subfieldExpression("data", "a\\nb'c") == "data[$$a\\nb'c$$]")
+  }
+
+  test("subfieldExpression backslash-only inputs are passed through unchanged (known wart)") {
+    // Known limitation: a backslash-only input (no unescaped `'`) takes the
+    // pass-through path because `hasOnlyEscapedQuotes` only inspects `'`
+    // characters. The emitted SQL is `'C:\path'`, where Snowflake's single-
+    // quoted lexer will interpret `\p` as "backslash followed by unknown
+    // escape, dropped" — i.e. data corruption (the literal becomes `C:path`).
+    //
+    // This is a pre-existing wart, not a SNOW-3511808 regression: pre-fix
+    // behaviour was identical. It is NOT a SQL-injection vector (no `'` or
+    // `$$` means the literal cannot be broken out of). A caller who needs a
+    // literal backslash in a field name should include an unescaped `'` in
+    // the same string (forcing dollar-quoting), or switch to one of the
+    // public APIs that funnel input through `singleQuote` (which uses the
+    // stricter `isProperlyQuoted` gate and dollar-quotes backslash-only
+    // inputs correctly).
+    assert(subfieldExpression("data", "C:\\path") == "data['C:\\path']")
+    assert(subfieldExpression("data", "a\\nb") == "data['a\\nb']")
   }
 
   test("subfieldExpression passes well-formed escaped bodies through unchanged") {
-    // Documented API contract (ColumnSuite.scala:497): callers may escape
+    // Documented API contract (ColumnSuite.scala): callers may pre-escape
     // their own single quotes. If the input is already well-formed (every `'`
-    // doubled), it is embedded verbatim — re-escaping would double-escape
-    // and corrupt the field name.
+    // doubled), it is embedded verbatim wrapped in `'…'` — preserving the
+    // exact SQL previously emitted for such inputs. Re-wrapping with `$$`
+    // here would change the textual form (still semantically valid, but
+    // unnecessary churn for callers that opted into the contract).
     assert(subfieldExpression("data", "date with '' and .") == "data['date with '' and .']")
     assert(subfieldExpression("data", "O''Brien") == "data['O''Brien']")
     // The two-character input `''` is itself a well-formed escaped body
@@ -86,15 +136,34 @@ class SqlInjectionSuite extends AnyFunSuite {
 
   // ---- singleQuote ---------------------------------------------------------
 
-  test("singleQuote wraps and escapes plain unquoted values") {
+  test("singleQuote wraps plain unquoted values in bare single quotes (no escaping needed)") {
+    // Backward-compat: plain inputs (containing neither `'` nor `\`) get the
+    // textually-unchanged `'value'` form. Pre-fix output for these inputs was
+    // also `'value'`, so downstream consumers that do string-equality checks
+    // against the canonical single-quoted form (e.g. `DataFrameWriter`'s
+    // `columnOrder` validator, which compares against `Set("'index'", "'name'")`
+    // and pattern-matches on `case "'name'"`) keep working unchanged. Only
+    // inputs that contain `'` or `\` — the SNOW-3511808 attack surface —
+    // switch to the new dollar-quoted form.
     assert(singleQuote("abc") == "'abc'")
     assert(singleQuote("") == "''")
     assert(singleQuote("hello world") == "'hello world'")
+    assert(singleQuote("index") == "'index'")
+    assert(singleQuote("name") == "'name'")
+    // SYSTEM$VERSION-style identifiers with a single `$` are safe under bare
+    // single-quote wrap (no `'` to break out, no `\` to escape-bypass).
+    assert(singleQuote("SYSTEM$VERSION") == "'SYSTEM$VERSION'")
+    // Even `$$` in the value is safe under bare wrap — single-quoted literals
+    // don't interpret `$$` as a delimiter.
+    assert(singleQuote("a$$b") == "'a$$b'")
   }
 
-  test("singleQuote escapes embedded quotes when wrapping unquoted input") {
-    assert(singleQuote("O'Brien") == "'O''Brien'")
-    assert(singleQuote("a'b'c") == "'a''b''c'")
+  test("singleQuote keeps embedded quotes and backslashes literal") {
+    // No internal escaping needed inside `$$…$$`.
+    assert(singleQuote("O'Brien") == "$$O'Brien$$")
+    assert(singleQuote("a'b'c") == "$$a'b'c$$")
+    assert(singleQuote("C:\\path\\to\\file") == "$$C:\\path\\to\\file$$")
+    assert(singleQuote("line1\\nline2") == "$$line1\\nline2$$")
   }
 
   test("singleQuote passes through properly pre-quoted values unchanged") {
@@ -109,27 +178,35 @@ class SqlInjectionSuite extends AnyFunSuite {
 
   test("singleQuote re-wraps inputs whose interior quotes are unbalanced") {
     // Bounded by `'` but the interior `'` is not doubled, so the value is
-    // NOT a well-formed literal. Pre-fix, this passed through verbatim and
-    // would break out of the literal scope when emitted into SQL. Post-fix,
-    // it is treated as an unquoted value and re-wrapped.
+    // NOT a well-formed pre-quoted literal. Pre-fix, this passed through
+    // verbatim and would break out of the literal scope when emitted into
+    // SQL. Post-fix, it falls to dollar-quoting and the payload is contained.
     val payload = "'a'; DROP TABLE x; --'"
     val sql = singleQuote(payload)
-    val expected = "'''a''; DROP TABLE x; --'''"
-    assert(sql == expected)
-    // Sanity: the result is one well-formed literal whose content equals the
-    // original payload. Snowflake's lexer reads only the outer two `'`s as
-    // string-literal delimiters; every other `'` in the result is part of a
-    // doubled-quote escape pair `''`.
+    assert(sql == "$$'a'; DROP TABLE x; --'$$")
   }
 
-  test("singleQuote defends against a closing-quote injection payload") {
+  test("singleQuote defends against the original closing-quote injection payload") {
     // Adversarial payload: try to terminate the literal early and append SQL.
-    // Not bounded by `'` so the early-return cannot fire; falls to the
-    // wrap-and-escape branch.
+    // Not bounded by `'` on both sides so the pass-through cannot fire; falls
+    // to dollar-quoting.
     val payload = "'); DROP TABLE users; --"
     val sql = singleQuote(payload)
-    val expected = "'''); DROP TABLE users; --'"
-    assert(sql == expected)
+    assert(sql == "$$'); DROP TABLE users; --$$")
+  }
+
+  test("singleQuote defends against the backslash-quote-escape bypass") {
+    // PR #281 review (@sfc-gh-heshah). Snowflake's single-quoted lexer reads
+    // `\'` as an alternative encoding of `'`, which would have defeated a
+    // quotes-only escape strategy. Dollar-quoting sidesteps the issue
+    // entirely — `\` is an ordinary character inside `$$…$$`.
+    val payload = "\\'; DROP TABLE x; --"
+    val sql = singleQuote(payload)
+    assert(sql == "$$\\'; DROP TABLE x; --$$")
+    // Sanity: the `\` and the `'` from the payload appear verbatim, and the
+    // literal delimiters are `$$` not `'`.
+    assert(sql.count(_ == '\\') == 1)
+    assert(sql.count(_ == '\'') == 1)
   }
 
   // ---- isProperlyQuoted (gate on singleQuote's pass-through branch) --------
@@ -153,25 +230,98 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(!isProperlyQuoted("'a'; DROP TABLE x; --'")) // injection-shaped
   }
 
-  // ---- escapeSingleQuotes (root primitive) ---------------------------------
+  // ---- dollarQuoteOrEscape (primary helper for the wrap branch) ------------
 
-  test("escapeSingleQuotes doubles every single quote and leaves other chars alone") {
-    assert(escapeSingleQuotes("") == "")
-    assert(escapeSingleQuotes("abc") == "abc")
-    assert(escapeSingleQuotes("'") == "''")
-    assert(escapeSingleQuotes("''") == "''''")
-    assert(escapeSingleQuotes("a'b") == "a''b")
-    assert(escapeSingleQuotes("don't") == "don''t")
+  test("dollarQuoteOrEscape uses dollar-quoting for the common case") {
+    // No `$$` in the value and no trailing `$` — the default, fast path.
+    assert(dollarQuoteOrEscape("") == "$$$$")
+    assert(dollarQuoteOrEscape("hello") == "$$hello$$")
+    // `'` and `\` ride inside `$$…$$` literally; that's the structural defence.
+    assert(dollarQuoteOrEscape("O'Brien") == "$$O'Brien$$")
+    assert(dollarQuoteOrEscape("C:\\path") == "$$C:\\path$$")
+    assert(dollarQuoteOrEscape("\\'; DROP TABLE x; --") == "$$\\'; DROP TABLE x; --$$")
+    // A single mid-string `$` is safe — only `$$` terminates the literal.
+    assert(dollarQuoteOrEscape("a$b") == "$$a$b$$")
+    // `SYSTEM$VERSION`-style identifiers with single `$` are common; ensure
+    // they survive untouched.
+    assert(dollarQuoteOrEscape("SYSTEM$VERSION") == "$$SYSTEM$VERSION$$")
   }
 
-  // ---- boundary tests requested in PR review (SNOW-3511808) ----------------
+  test("dollarQuoteOrEscape falls back to single-quote when value contains $$") {
+    // Embedded `$$` would close the dollar-quoted literal early. Fall back to
+    // a single-quoted literal (with `'` and `\` escaped) so the payload
+    // remains contained.
+    assert(dollarQuoteOrEscape("a$$b") == "'a$$b'")
+    assert(dollarQuoteOrEscape("$$") == "'$$'")
+    assert(dollarQuoteOrEscape("foo$$bar$$baz") == "'foo$$bar$$baz'")
+  }
+
+  test("dollarQuoteOrEscape falls back to single-quote when value ends with $") {
+    // A trailing `$` adjacent to our closing `$$` would form `$$$`, which
+    // the lexer would parse as a closing `$$` followed by an extraneous `$`
+    // — a syntax error rather than an injection, but still wrong.
+    assert(dollarQuoteOrEscape("$") == "'$'")
+    assert(dollarQuoteOrEscape("abc$") == "'abc$'")
+    assert(dollarQuoteOrEscape("a$b$") == "'a$b$'")
+  }
+
+  test("dollarQuoteOrEscape fallback path still escapes ' and \\ for injection-safety") {
+    // When the value forces the single-quote fallback AND contains characters
+    // that would attack a single-quoted literal, `escapeForSingleQuotedLiteral`
+    // doubles both `\` and `'` so the payload is fully contained.
+    // Input: `$$\'; DROP TABLE x; --` — `$$` triggers fallback, `\'` is the
+    // backslash-quote-escape bypass.
+    assert(
+      dollarQuoteOrEscape("$$\\'; DROP TABLE x; --") ==
+        "'$$\\\\''; DROP TABLE x; --'")
+    // Input: `a$$b'c` — `$$` triggers fallback, `'` needs escaping.
+    assert(dollarQuoteOrEscape("a$$b'c") == "'a$$b''c'")
+  }
+
+  // ---- escapeForSingleQuotedLiteral (fallback-path primitive) --------------
+
+  test("escapeForSingleQuotedLiteral doubles every single quote and leaves plain text alone") {
+    assert(escapeForSingleQuotedLiteral("") == "")
+    assert(escapeForSingleQuotedLiteral("abc") == "abc")
+    assert(escapeForSingleQuotedLiteral("'") == "''")
+    assert(escapeForSingleQuotedLiteral("''") == "''''")
+    assert(escapeForSingleQuotedLiteral("a'b") == "a''b")
+    assert(escapeForSingleQuotedLiteral("don't") == "don''t")
+  }
+
+  test("escapeForSingleQuotedLiteral doubles every backslash") {
+    // Snowflake's single-quoted lexer interprets `\` as an escape character
+    // (e.g. `\b` → BACKSPACE, `\'` → `'`). Doubling `\` to `\\` makes the
+    // lexer re-read it as a literal `\`, which is the only way to faithfully
+    // round-trip a value that contains backslashes through a single-quoted
+    // literal (the fallback path).
+    assert(escapeForSingleQuotedLiteral("\\") == "\\\\")
+    assert(escapeForSingleQuotedLiteral("a\\b") == "a\\\\b")
+    assert(escapeForSingleQuotedLiteral("\\\\") == "\\\\\\\\")
+    // `\n` (two characters: backslash + n) becomes `\\n` so Snowflake
+    // re-reads it as `\` followed by `n`, not the single newline character.
+    assert(escapeForSingleQuotedLiteral("\\n") == "\\\\n")
+  }
+
+  test("escapeForSingleQuotedLiteral escapes backslash THEN quote (mixed input)") {
+    // Mixed payload covering the SNOW-3511808 backslash bypass: a `'`
+    // preceded by a `\`. Quotes-only escaping would have produced `\''`,
+    // which Snowflake reads as `\'` (alternative quote-escape) followed by
+    // a stray `'` that closes the literal early. Doubling `\` first yields
+    // `\\''`, which Snowflake reads as `\` followed by a doubled-quote
+    // escape — the literal stays closed by exactly its outer `'`s.
+    assert(escapeForSingleQuotedLiteral("\\'") == "\\\\''")
+    assert(escapeForSingleQuotedLiteral("'\\") == "''\\\\")
+    assert(escapeForSingleQuotedLiteral("a\\'b") == "a\\\\''b")
+  }
+
+  // ---- boundary tests requested in earlier PR review -----------------------
 
   test("singleQuote: empty literal '' passes through unchanged") {
     // Boundary case: the two-character input `''` is a well-formed empty SQL
-    // string literal. `isProperlyQuoted` accepts it, so it round-trips as-is.
-    // Without this guarantee, a caller that explicitly passed the empty
-    // literal would see it re-wrapped to `''''` (a literal containing one
-    // single quote), changing its semantics.
+    // string literal. `isProperlyQuoted` accepts it, so it round-trips as-is
+    // (instead of being re-wrapped to `$$$$`, which would be semantically
+    // identical but textually different).
     assert(singleQuote("''") == "''")
   }
 
@@ -179,7 +329,7 @@ class SqlInjectionSuite extends AnyFunSuite {
     // The `(expr: String, field: Int)` overload addresses array/struct fields
     // by ordinal. Integers cannot carry quote characters and cannot escape
     // the surrounding `[...]` syntax, so this overload deliberately bypasses
-    // the string-quoting path and emits the integer directly. This test is
+    // the literal-wrapping path and emits the integer directly. This test is
     // here so a future reader of `SqlInjectionSuite` does not wonder whether
     // the overload was accidentally left unprotected.
     assert(subfieldExpression("data", 0) == "data[0]")
@@ -194,18 +344,18 @@ class SqlInjectionSuite extends AnyFunSuite {
   // `package.scala`: `collateExpression`, `selectFromPathWithFormatStatement`,
   // and `copyIntoTable`. Each test uses an adversarial input that would
   // previously have terminated the literal early and injected SQL; the fix
-  // contains the entire payload inside a single well-formed string literal.
+  // contains the entire payload inside a single dollar-quoted string literal.
 
-  test("collateExpression escapes an injected collation spec (SNOW-3511808 side-fix)") {
+  test("collateExpression dollar-quotes an injected collation spec") {
     // collationSpec flows from `Column.collate(String)` — a public API. Pre-fix
     // `singleQuote` would have passed `"en_US'; DROP TABLE x; --"` through with
     // only the bare wrap, embedding raw `'` characters into the emitted SQL
     // and breaking out of the literal scope on the second `'`.
     val sql = collateExpression("col", "en_US'; DROP TABLE x; --")
-    assert(sql == "col COLLATE 'en_US''; DROP TABLE x; --'")
+    assert(sql == "col COLLATE $$en_US'; DROP TABLE x; --$$")
   }
 
-  test("selectFromPathWithFormatStatement escapes injected formatName and pattern") {
+  test("selectFromPathWithFormatStatement dollar-quotes injected formatName and pattern") {
     val sql = selectFromPathWithFormatStatement(
       project = Seq.empty,
       path = "@stage",
@@ -213,16 +363,17 @@ class SqlInjectionSuite extends AnyFunSuite {
       pattern = Some(".*csv'; DROP TABLE y; --"))
     // Asserting the exact emitted string is brittle (the surrounding builder
     // is dense with spaces); the security property is that both option values
-    // were funneled through `singleQuote`, doubled their interior `'`, and
-    // landed in the SQL as well-formed single-quoted literals.
-    assert(sql.contains("'MY_FMT''; DROP TABLE x; --'"))
-    assert(sql.contains("'.*csv''; DROP TABLE y; --'"))
-    // And nothing got past with a raw, unescaped quote in the payload region.
+    // were funneled through `singleQuote`, dollar-quoted, and landed in the
+    // SQL as well-formed `$$…$$` literals.
+    assert(sql.contains("$$MY_FMT'; DROP TABLE x; --$$"))
+    assert(sql.contains("$$.*csv'; DROP TABLE y; --$$"))
+    // And nothing got past with a raw, unescaped quote in the payload region
+    // (the substring that would indicate early literal termination).
     assert(!sql.contains("'MY_FMT';"))
     assert(!sql.contains("'.*csv';"))
   }
 
-  test("copyIntoTable escapes an injected COPY INTO pattern") {
+  test("copyIntoTable dollar-quotes an injected COPY INTO pattern") {
     val sql = copyIntoTable(
       tableName = "T",
       filePath = "@stage",
@@ -232,12 +383,10 @@ class SqlInjectionSuite extends AnyFunSuite {
       pattern = Some(".*csv'; DROP TABLE x; --"),
       columnNames = Seq.empty,
       transformations = Seq.empty)
-    // The injected `'` inside the pattern is doubled, so the payload stays
-    // contained inside a single well-formed SQL string literal.
-    assert(sql.contains("'.*csv''; DROP TABLE x; --'"))
-    // Same property as above: the unescaped `'.*csv';` substring (which
-    // would indicate the literal was terminated early at the injection
-    // point) must not appear anywhere in the emitted SQL.
+    // The injected `'` rides inside the `$$…$$` literal verbatim — no
+    // escaping needed, no way to break out.
+    assert(sql.contains("$$.*csv'; DROP TABLE x; --$$"))
+    // Same property as above: the early-termination substring must not appear.
     assert(!sql.contains("'.*csv';"))
   }
 }


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes SNOW-3511808

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   *Escape single quotes in subfieldExpression and singleQuote.*
