### PR TITLE
SNOW-3414827: remove ENABLE_JAVA_UDAF usage from UDAF suites

### DIFF
--- a/src/test/java/com/snowflake/snowpark_test/JavaUDAFClientSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDAFClientSuite.java
@@ -18,22 +18,18 @@ import org.junit.Test;
 public class JavaUDAFClientSuite extends UDFTestBase {
   @Test
   public void testJavaTemporaryUDAF() {
-    udafTest(
-        () -> {
-          MySumUDAF udaf = new MySumUDAF();
-          AggregateFunction mySum = getSession().udaf().registerTemporary("java_my_sum", udaf);
+    MySumUDAF udaf = new MySumUDAF();
+    AggregateFunction mySum = getSession().udaf().registerTemporary("java_my_sum", udaf);
 
-          DataFrame df =
-              getSession()
-                  .createDataFrame(
-                      new Row[] {Row.create(1), Row.create(2), Row.create(3)},
-                      StructType.create(new StructField("a", DataTypes.IntegerType)));
+    DataFrame df =
+        getSession()
+            .createDataFrame(
+                new Row[] {Row.create(1), Row.create(2), Row.create(3)},
+                StructType.create(new StructField("a", DataTypes.IntegerType)));
 
-          Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
-          assertEquals(1, result.length);
-          assertEquals(6L, result[0].getLong(0));
-        },
-        getSession());
+    Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
+    assertEquals(1, result.length);
+    assertEquals(6L, result[0].getLong(0));
   }
 
   /**
@@ -43,22 +39,18 @@ public class JavaUDAFClientSuite extends UDFTestBase {
    */
   @Test
   public void testJavaUDAFWithImmutableState() {
-    udafTest(
-        () -> {
-          AggregateFunction mySum =
-              getSession().udaf().registerTemporary("java_immutable_sum", new MyImmutableSumUDAF());
+    AggregateFunction mySum =
+        getSession().udaf().registerTemporary("java_immutable_sum", new MyImmutableSumUDAF());
 
-          DataFrame df =
-              getSession()
-                  .createDataFrame(
-                      new Row[] {Row.create(1), Row.create(2), Row.create(3)},
-                      StructType.create(new StructField("a", DataTypes.IntegerType)));
+    DataFrame df =
+        getSession()
+            .createDataFrame(
+                new Row[] {Row.create(1), Row.create(2), Row.create(3)},
+                StructType.create(new StructField("a", DataTypes.IntegerType)));
 
-          Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
-          assertEquals(1, result.length);
-          assertEquals(6L, result[0].getLong(0));
-        },
-        getSession());
+    Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
+    assertEquals(1, result.length);
+    assertEquals(6L, result[0].getLong(0));
   }
 
   /**
@@ -67,25 +59,20 @@ public class JavaUDAFClientSuite extends UDFTestBase {
    */
   @Test
   public void testJavaUDAFWithLargeClosure() {
-    udafTest(
-        () -> {
-          MyLargeClosureUDAF udaf = new MyLargeClosureUDAF(1024);
-          assert JavaUtils.serialize(udaf).length > 8192
-              : "Serialized UDAF should exceed 8KB to test the large closure path";
+    MyLargeClosureUDAF udaf = new MyLargeClosureUDAF(1024);
+    assert JavaUtils.serialize(udaf).length > 8192
+        : "Serialized UDAF should exceed 8KB to test the large closure path";
 
-          AggregateFunction mySum =
-              getSession().udaf().registerTemporary("java_large_closure_sum", udaf);
+    AggregateFunction mySum = getSession().udaf().registerTemporary("java_large_closure_sum", udaf);
 
-          DataFrame df =
-              getSession()
-                  .createDataFrame(
-                      new Row[] {Row.create(1), Row.create(2), Row.create(3)},
-                      StructType.create(new StructField("a", DataTypes.IntegerType)));
+    DataFrame df =
+        getSession()
+            .createDataFrame(
+                new Row[] {Row.create(1), Row.create(2), Row.create(3)},
+                StructType.create(new StructField("a", DataTypes.IntegerType)));
 
-          Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
-          assertEquals(1, result.length);
-          assertEquals(6L, result[0].getLong(0));
-        },
-        getSession());
+    Row[] result = df.select(mySum.apply(Functions.col("a"))).collect();
+    assertEquals(1, result.length);
+    assertEquals(6L, result[0].getLong(0));
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDAFClientSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDAFClientSuite.java
@@ -19,7 +19,7 @@ public class JavaUDAFClientSuite extends UDFTestBase {
   @Test
   public void testJavaTemporaryUDAF() {
     MySumUDAF udaf = new MySumUDAF();
-    AggregateFunction mySum = getSession().udaf().registerTemporary("java_my_sum", udaf);
+    AggregateFunction mySum = getSession().udaf().registerTemporary(udaf);
 
     DataFrame df =
         getSession()
@@ -39,8 +39,7 @@ public class JavaUDAFClientSuite extends UDFTestBase {
    */
   @Test
   public void testJavaUDAFWithImmutableState() {
-    AggregateFunction mySum =
-        getSession().udaf().registerTemporary("java_immutable_sum", new MyImmutableSumUDAF());
+    AggregateFunction mySum = getSession().udaf().registerTemporary(new MyImmutableSumUDAF());
 
     DataFrame df =
         getSession()
@@ -63,7 +62,7 @@ public class JavaUDAFClientSuite extends UDFTestBase {
     assert JavaUtils.serialize(udaf).length > 8192
         : "Serialized UDAF should exceed 8KB to test the large closure path";
 
-    AggregateFunction mySum = getSession().udaf().registerTemporary("java_large_closure_sum", udaf);
+    AggregateFunction mySum = getSession().udaf().registerTemporary(udaf);
 
     DataFrame df =
         getSession()

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDAFMultiArgSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDAFMultiArgSuite.java
@@ -31,603 +31,515 @@ public class JavaUDAFMultiArgSuite extends UDFTestBase {
   @Test
   public void testJavaUDAFOf2() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf2());
-          // sum of (1+2) + (2+3) + (3+4) = 3 + 5 + 7 = 15
-          DataFrame df = createTestData();
-          Row[] rows = df.select(udaf.apply(col("a"), col("a").plus(lit(1)))).collect();
-          assertEquals(1, rows.length);
-          assertEquals(15L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf2());
+    // sum of (1+2) + (2+3) + (3+4) = 3 + 5 + 7 = 15
+    DataFrame df = createTestData();
+    Row[] rows = df.select(udaf.apply(col("a"), col("a").plus(lit(1)))).collect();
+    assertEquals(1, rows.length);
+    assertEquals(15L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf3() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf3());
-          // sum of (1+2+3) + (2+3+4) + (3+4+5) = 6 + 9 + 12 = 27
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(udaf.apply(col("a"), col("a").plus(lit(1)), col("a").plus(lit(2))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(27L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf3());
+    // sum of (1+2+3) + (2+3+4) + (3+4+5) = 6 + 9 + 12 = 27
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(udaf.apply(col("a"), col("a").plus(lit(1)), col("a").plus(lit(2)))).collect();
+    assertEquals(1, rows.length);
+    assertEquals(27L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf4() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf4());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(42L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf4());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"), col("a").plus(lit(1)), col("a").plus(lit(2)), col("a").plus(lit(3))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(42L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf5() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf5());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(60L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf5());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(60L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf6() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf6());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(81L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf6());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(81L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf7() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf7());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(105L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf7());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(105L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf8() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf8());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(132L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf8());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(132L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf9() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf9());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(162L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf9());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(162L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf10() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf10());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(195L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf10());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(195L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf11() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf11());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(231L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf11());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(231L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf12() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf12());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(270L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf12());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(270L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf13() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf13());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(312L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf13());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(312L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf14() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf14());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(357L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf14());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(357L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf15() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf15());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(405L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf15());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(405L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf16() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf16());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(456L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf16());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(456L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf17() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf17());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(510L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf17());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(510L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf18() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf18());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16)),
-                          col("a").plus(lit(17))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(567L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf18());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16)),
+                    col("a").plus(lit(17))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(567L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf19() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf19());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16)),
-                          col("a").plus(lit(17)),
-                          col("a").plus(lit(18))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(627L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf19());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16)),
+                    col("a").plus(lit(17)),
+                    col("a").plus(lit(18))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(627L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf20() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf20());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16)),
-                          col("a").plus(lit(17)),
-                          col("a").plus(lit(18)),
-                          col("a").plus(lit(19))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(690L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf20());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16)),
+                    col("a").plus(lit(17)),
+                    col("a").plus(lit(18)),
+                    col("a").plus(lit(19))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(690L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf21() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf21());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16)),
-                          col("a").plus(lit(17)),
-                          col("a").plus(lit(18)),
-                          col("a").plus(lit(19)),
-                          col("a").plus(lit(20))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(756L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf21());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16)),
+                    col("a").plus(lit(17)),
+                    col("a").plus(lit(18)),
+                    col("a").plus(lit(19)),
+                    col("a").plus(lit(20))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(756L, rows[0].getLong(0));
   }
 
   @Test
   public void testJavaUDAFOf22() {
     ensureDependencies();
-    udafTest(
-        () -> {
-          AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf22());
-          DataFrame df = createTestData();
-          Row[] rows =
-              df.select(
-                      udaf.apply(
-                          col("a"),
-                          col("a").plus(lit(1)),
-                          col("a").plus(lit(2)),
-                          col("a").plus(lit(3)),
-                          col("a").plus(lit(4)),
-                          col("a").plus(lit(5)),
-                          col("a").plus(lit(6)),
-                          col("a").plus(lit(7)),
-                          col("a").plus(lit(8)),
-                          col("a").plus(lit(9)),
-                          col("a").plus(lit(10)),
-                          col("a").plus(lit(11)),
-                          col("a").plus(lit(12)),
-                          col("a").plus(lit(13)),
-                          col("a").plus(lit(14)),
-                          col("a").plus(lit(15)),
-                          col("a").plus(lit(16)),
-                          col("a").plus(lit(17)),
-                          col("a").plus(lit(18)),
-                          col("a").plus(lit(19)),
-                          col("a").plus(lit(20)),
-                          col("a").plus(lit(21))))
-                  .collect();
-          assertEquals(1, rows.length);
-          assertEquals(825L, rows[0].getLong(0));
-        },
-        getSession());
+    AggregateFunction udaf = getSession().udaf().registerTemporary(new MyJavaUDAFOf22());
+    DataFrame df = createTestData();
+    Row[] rows =
+        df.select(
+                udaf.apply(
+                    col("a"),
+                    col("a").plus(lit(1)),
+                    col("a").plus(lit(2)),
+                    col("a").plus(lit(3)),
+                    col("a").plus(lit(4)),
+                    col("a").plus(lit(5)),
+                    col("a").plus(lit(6)),
+                    col("a").plus(lit(7)),
+                    col("a").plus(lit(8)),
+                    col("a").plus(lit(9)),
+                    col("a").plus(lit(10)),
+                    col("a").plus(lit(11)),
+                    col("a").plus(lit(12)),
+                    col("a").plus(lit(13)),
+                    col("a").plus(lit(14)),
+                    col("a").plus(lit(15)),
+                    col("a").plus(lit(16)),
+                    col("a").plus(lit(17)),
+                    col("a").plus(lit(18)),
+                    col("a").plus(lit(19)),
+                    col("a").plus(lit(20)),
+                    col("a").plus(lit(21))))
+            .collect();
+    assertEquals(1, rows.length);
+    assertEquals(825L, rows[0].getLong(0));
   }
 }
 

--- a/src/test/java/com/snowflake/snowpark_test/TestFunctions.java
+++ b/src/test/java/com/snowflake/snowpark_test/TestFunctions.java
@@ -19,7 +19,7 @@ public abstract class TestFunctions {
         (Boolean) JavaToScalaConvertor.javaToScalaSession(session).conn().isStoredProc();
     String oldSfTimezone =
         isStoredProc
-            ? session.sql("select CURRENT_TIMEZONE()").collect()[0].getString(0)
+            ? TimeZone.getDefault().getID()
             : session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect()[0].getString(1);
     String testTimezone = isStoredProc ? oldSfTimezone : "America/Los_Angeles";
     try {

--- a/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
+++ b/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
@@ -3,8 +3,6 @@ package com.snowflake.snowpark_test;
 import com.snowflake.snowpark.TestUtils;
 import com.snowflake.snowpark.internal.JavaUtils;
 import com.snowflake.snowpark_java.Session;
-import java.util.HashMap;
-import java.util.Map;
 
 public abstract class UDFTestBase extends TestFunctions {
   protected String defaultProfile = TestUtils.defaultProfile();
@@ -55,17 +53,5 @@ public abstract class UDFTestBase extends TestFunctions {
 
   protected void addDepsToClassPath(Session session, String stageName) {
     TestUtils.addDepsToClassPathJava(session, stageName);
-  }
-
-  protected void udafTest(TestMethod thunk, Session session) {
-    Map<String, String> params = new HashMap<>();
-    params.put("ENABLE_JAVA_UDAF", "TRUE");
-    try {
-      params.forEach(
-          (name, value) -> session.sql("alter session set " + name + " = " + value).collect());
-      thunk.run();
-    } finally {
-      params.forEach((name, value) -> session.sql("alter session unset " + name).collect());
-    }
   }
 }

--- a/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
+++ b/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
@@ -335,18 +335,6 @@ trait SNTestBase extends AnyFunSuite with BeforeAndAfterAll with SFTestUtils wit
       skipPreprod = true)(thunk)
     // disable these tests on preprod daily tests until these parameters are enabled by default.
   }
-
-  def enableScala213UdxfSprocParams(session: Session): Unit = {
-    if (ScalaCompatVersion.contentEquals("2.13")) {
-      runQuery("alter session set ENABLE_SCALA_UDF_RUNTIME_2_13=true", session)
-    }
-  }
-
-  def disableScala213UdxfSprocParams(session: Session): Unit = {
-    if (ScalaCompatVersion.contentEquals("2.13")) {
-      runQuery("alter session set ENABLE_SCALA_UDF_RUNTIME_2_13=false", session)
-    }
-  }
 }
 
 trait SnowTestFiles {

--- a/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
+++ b/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
@@ -200,7 +200,7 @@ trait SNTestBase extends AnyFunSuite with BeforeAndAfterAll with SFTestUtils wit
     val defaultTimezone = TimeZone.getDefault
     val oldSfTimeZone =
       if (isStoredProc(session)) {
-        session.sql("select CURRENT_TIMEZONE()").collect().head.getString(0)
+        TimeZone.getDefault.getID
       } else {
         session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
       }

--- a/src/test/scala/com/snowflake/snowpark/TestData.scala
+++ b/src/test/scala/com/snowflake/snowpark/TestData.scala
@@ -9,7 +9,7 @@ trait TestData extends SNTestBase {
   val defaultTimezone = TimeZone.getDefault
   val oldSfTimeZone =
     if (isStoredProc(session)) {
-      session.sql("select CURRENT_TIMEZONE()").collect().head.getString(0)
+      TimeZone.getDefault.getID
     } else {
       session.sql("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION").collect().head.getString(1)
     }

--- a/src/test/scala/com/snowflake/snowpark/UDFClasspathSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDFClasspathSuite.scala
@@ -17,12 +17,6 @@ class UDFClasspathSuite extends SNTestBase {
   override def beforeAll: Unit = {
     super.beforeAll
     TestUtils.addDepsToClassPath(session)
-    enableScala213UdxfSprocParams(session)
-  }
-
-  override def afterAll: Unit = {
-    disableScala213UdxfSprocParams(session)
-    super.afterAll
   }
 
   test("Test that jars uploaded to different stages") {

--- a/src/test/scala/com/snowflake/snowpark/UDFInternalSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDFInternalSuite.scala
@@ -21,12 +21,10 @@ class UDFInternalSuite extends TestData {
       TestUtils.addDepsToClassPath(session, Some(stageName))
       TestUtils.addDepsToClassPath(newSession, Some(stageName))
     }
-    enableScala213UdxfSprocParams(session)
   }
 
   override def afterAll: Unit = {
     dropStage(stageName)
-    disableScala213UdxfSprocParams(session)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark/UDFRegistrationSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDFRegistrationSuite.scala
@@ -19,12 +19,6 @@ class UDFRegistrationSuite extends SNTestBase with FileUtils {
     if (!isStoredProc(session)) {
       TestUtils.addDepsToClassPath(session)
     }
-    enableScala213UdxfSprocParams(session)
-  }
-
-  override def afterAll: Unit = {
-    disableScala213UdxfSprocParams(session)
-    super.afterAll
   }
 
   test("Test that jar files are uploaded to stage correctly") {

--- a/src/test/scala/com/snowflake/snowpark/UDTFInternalSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UDTFInternalSuite.scala
@@ -13,12 +13,6 @@ class UDTFInternalSuite extends SNTestBase {
     if (!isStoredProc(session)) {
       TestUtils.addDepsToClassPath(session)
     }
-    enableScala213UdxfSprocParams(session)
-  }
-
-  override def afterAll: Unit = {
-    disableScala213UdxfSprocParams(session)
-    super.afterAll
   }
 
   test("Unit test for UDTF0") {

--- a/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
@@ -38,8 +38,6 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
       // In stored procs mode, there is only one session
       TestUtils.addDepsToClassPath(newSession, Some(tmpStageName))
     }
-    enableScala213UdxfSprocParams(session)
-    enableScala213UdxfSprocParams(newSession)
   }
 
   override def afterAll: Unit = {
@@ -51,8 +49,6 @@ class AsyncJobSuite extends TestData with BeforeAndAfterEach {
     dropTable(tableName)
     dropTable(tableName1)
     dropTable(tableName2)
-    disableScala213UdxfSprocParams(session)
-    disableScala213UdxfSprocParams(newSession)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
@@ -29,16 +29,12 @@ class PermanentUDFSuite extends TestData {
       // In stored procs mode, there is only one session
       TestUtils.addDepsToClassPath(newSession, Some(stageName))
     }
-    enableScala213UdxfSprocParams(session)
-    enableScala213UdxfSprocParams(newSession)
   }
 
   override def afterAll: Unit = {
     dropStage(stageName)
     removeFile(tempDirectory1.getAbsolutePath, session)
     removeFile(tempDirectory2.getAbsolutePath, session)
-    disableScala213UdxfSprocParams(session)
-    disableScala213UdxfSprocParams(newSession)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
@@ -25,14 +25,10 @@ class PermanentUDTFSuite extends TestData {
       TestUtils.addDepsToClassPath(session, Some(stageName))
       TestUtils.addDepsToClassPath(newSession, Some(stageName))
     }
-    enableScala213UdxfSprocParams(session)
-    enableScala213UdxfSprocParams(newSession)
   }
 
   override def afterAll: Unit = {
     dropStage(stageName)
-    disableScala213UdxfSprocParams(session)
-    disableScala213UdxfSprocParams(newSession)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
@@ -16,12 +16,10 @@ class StoredProcedureSuite extends SNTestBase {
     if (!isStoredProc(session)) {
       TestUtils.addDepsToClassPath(session, Some(testStage))
     }
-    enableScala213UdxfSprocParams(session)
   }
 
   override def afterAll: Unit = {
     dropStage(testStage)
-    disableScala213UdxfSprocParams(session)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/UDAFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/UDAFSuite.scala
@@ -738,16 +738,6 @@ class ScalaSumUDAF22
 class UDAFSuite extends TestData {
   import session.implicits._
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-    session.sql("ALTER SESSION SET ENABLE_JAVA_UDAF = TRUE").collect()
-  }
-
-  override def afterAll(): Unit = {
-    session.sql("ALTER SESSION UNSET ENABLE_JAVA_UDAF").collect()
-    super.afterAll()
-  }
-
   // ==================== Java UDAF Tests ====================
 
   test("testTemporaryJavaUDAF") {

--- a/src/test/scala/com/snowflake/snowpark_test/UDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/UDFSuite.scala
@@ -53,7 +53,6 @@ trait UDFSuite extends TestData {
     if (!isStoredProc(session)) {
       TestUtils.addDepsToClassPath(session)
     }
-    enableScala213UdxfSprocParams(session)
   }
 
   override def afterAll: Unit = {
@@ -64,7 +63,6 @@ trait UDFSuite extends TestData {
     dropTable(tableName)
     dropTable(semiStructuredTable)
     runQuery(s"DROP STAGE IF EXISTS $tmpStageName", session)
-    disableScala213UdxfSprocParams(session)
     super.afterAll()
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/UDTFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/UDTFSuite.scala
@@ -28,14 +28,11 @@ class UDTFSuite extends TestData {
       .toDF("c1", "c2")
       .write
       .saveAsTable(wordCountTableName)
-
-    enableScala213UdxfSprocParams(session)
   }
 
   override def afterAll: Unit = {
     dropTable(wordCountTableName)
     dropTable(tableName)
-    disableScala213UdxfSprocParams(session)
     super.afterAll
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/UdxOpenTelemetrySuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/UdxOpenTelemetrySuite.scala
@@ -11,12 +11,6 @@ class UdxOpenTelemetrySuite extends OpenTelemetryEnabled {
     if (!isStoredProc(session)) {
       TestUtils.addDepsToClassPath(session)
     }
-    enableScala213UdxfSprocParams(session)
-  }
-
-  override def afterAll: Unit = {
-    disableScala213UdxfSprocParams(session)
-    super.afterAll
   }
 
   test("udf") {


### PR DESCRIPTION
The following test-only changes were committed directly to the `v1.19.x_main` branch to fix server-side client test infrastructure failures and need to be brought into `main` before the next release cut.

- SNOW-3414827: remove ENABLE_JAVA_UDAF usage from UDAF suites
- SNOW-3414827: use registerTemporary without explicit name
- fix test initialization in stored procs
- remove scala 2.13 parameter modifiers in test suites

1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes [SNOW-3689054](https://snowflakecomputing.atlassian.net/browse/SNOW-3689054)

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

   Already tested via server-side tests with the `v1.19.1` release.

[SNOW-3689054]: https://snowflakecomputing.atlassian.net/browse/SNOW-3689054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ