### PR TITLE
SNOW-3746508 Snowpark Java SDK: add interval type support for UDFs & Sprocs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,8 @@ lazy val javadocSettings = inConfig(Javadoc)(Defaults.configSettings) ++ Seq(
   Javadoc / packageDoc / artifactName := ((sv, mod, art) =>
     "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"))
 
-val jdbcVersion = "3.24.2"
+// 3.27.0+ required for native INTERVAL → java.time.Duration / Period ResultSet reads
+val jdbcVersion = "3.27.1"
 val jacksonVersion = "2.18.0"
 val openTelemetryVersion = "1.39.0"
 val slf4jVersion = "2.0.16"

--- a/src/main/java/com/snowflake/snowpark_java/types/DataTypes.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/DataTypes.java
@@ -116,6 +116,22 @@ public final class DataTypes {
   public static final VariantType VariantType = new VariantType();
 
   /**
+   * Retrieves the DayTimeIntervalType object. This maps to INTERVAL DAY TO SECOND in Snowflake.
+   * Java UDF/sproc handlers receive and return {@link java.time.Duration} for this type.
+   *
+   * @since 1.14.0
+   */
+  public static final DayTimeIntervalType DayTimeIntervalType = new DayTimeIntervalType();
+
+  /**
+   * Retrieves the YearMonthIntervalType object. This maps to INTERVAL YEAR TO MONTH in Snowflake.
+   * Java UDF/sproc handlers receive and return {@link java.time.Period} for this type.
+   *
+   * @since 1.14.0
+   */
+  public static final YearMonthIntervalType YearMonthIntervalType = new YearMonthIntervalType();
+
+  /**
    * Creates a new DecimalType object.
    *
    * @param precision An int number representing the precision

--- a/src/main/java/com/snowflake/snowpark_java/types/DayTimeIntervalType.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/DayTimeIntervalType.java
@@ -3,8 +3,8 @@ package com.snowflake.snowpark_java.types;
 /**
  * Day-time interval data type. This maps to INTERVAL DAY TO SECOND data type in Snowflake.
  *
- * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to
- * Java handlers as {@link java.time.Duration}.
+ * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to Java
+ * handlers as {@link java.time.Duration}.
  *
  * @since 1.14.0
  */

--- a/src/main/java/com/snowflake/snowpark_java/types/DayTimeIntervalType.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/DayTimeIntervalType.java
@@ -1,0 +1,13 @@
+package com.snowflake.snowpark_java.types;
+
+/**
+ * Day-time interval data type. This maps to INTERVAL DAY TO SECOND data type in Snowflake.
+ *
+ * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to
+ * Java handlers as {@link java.time.Duration}.
+ *
+ * @since 1.14.0
+ */
+public class DayTimeIntervalType extends DataType {
+  DayTimeIntervalType() {}
+}

--- a/src/main/java/com/snowflake/snowpark_java/types/YearMonthIntervalType.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/YearMonthIntervalType.java
@@ -1,0 +1,13 @@
+package com.snowflake.snowpark_java.types;
+
+/**
+ * Year-month interval data type. This maps to INTERVAL YEAR TO MONTH data type in Snowflake.
+ *
+ * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to
+ * Java handlers as {@link java.time.Period}.
+ *
+ * @since 1.14.0
+ */
+public class YearMonthIntervalType extends DataType {
+  YearMonthIntervalType() {}
+}

--- a/src/main/java/com/snowflake/snowpark_java/types/YearMonthIntervalType.java
+++ b/src/main/java/com/snowflake/snowpark_java/types/YearMonthIntervalType.java
@@ -3,8 +3,8 @@ package com.snowflake.snowpark_java.types;
 /**
  * Year-month interval data type. This maps to INTERVAL YEAR TO MONTH data type in Snowflake.
  *
- * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to
- * Java handlers as {@link java.time.Period}.
+ * <p>At the UDF/sproc boundary, values are transmitted as Arrow MonthDayNano and surfaced to Java
+ * handlers as {@link java.time.Period}.
  *
  * @since 1.14.0
  */

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -3,6 +3,7 @@ package com.snowflake.snowpark
 import java.io.{File, FileInputStream, FileNotFoundException}
 import java.net.URI
 import java.sql.{Connection, Date, Time, Timestamp}
+import java.time.{Duration, Period}
 import java.util.{Properties, Map => JMap, Set => JSet}
 import java.util.concurrent.{ConcurrentHashMap, ForkJoinPool, ForkJoinWorkerThread}
 import com.snowflake.snowpark.internal.analyzer._
@@ -844,7 +845,7 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
       {
         val sfType = field.dataType match {
           case _ @(VariantType | _: ArrayType | _: MapType | GeographyType | GeometryType |
-              TimeType | DateType | TimestampType) =>
+              TimeType | DateType | TimestampType | DayTimeIntervalType | YearMonthIntervalType) =>
             StringType
           case other => other
         }
@@ -871,6 +872,8 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
         case (value: Time, TimeType) => value.toString
         case (value: Date, DateType) => value.toString
         case (value: Timestamp, TimestampType) => value.toString
+        case (value: Duration, DayTimeIntervalType) => DataTypeMapper.formatDuration(value)
+        case (value: Period, YearMonthIntervalType) => DataTypeMapper.formatPeriod(value)
         case (value, _: AtomicType) => value
         case (value: Variant, VariantType) => value.asJsonString()
         case (value: Geography, GeographyType) => value.asGeoJSON()
@@ -893,6 +896,8 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
         case TimeType => callUDF("to_time", column(field.name)).as(field.name)
         case DateType => callUDF("to_date", column(field.name)).as(field.name)
         case TimestampType => callUDF("to_timestamp", column(field.name)).as(field.name)
+        case DayTimeIntervalType => column(field.name).cast(DayTimeIntervalType).as(field.name)
+        case YearMonthIntervalType => column(field.name).cast(YearMonthIntervalType).as(field.name)
         case VariantType => to_variant(parse_json(column(field.name))).as(field.name)
         case GeographyType => callUDF("to_geography", column(field.name)).as(field.name)
         case GeometryType => callUDF("to_geometry", column(field.name)).as(field.name)

--- a/src/main/scala/com/snowflake/snowpark/internal/DataTypeParser.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/DataTypeParser.scala
@@ -7,6 +7,7 @@ import com.snowflake.snowpark.types.{
   ByteType,
   DataType,
   DateType,
+  DayTimeIntervalType,
   DecimalType,
   DoubleType,
   FloatType,
@@ -19,7 +20,8 @@ import com.snowflake.snowpark.types.{
   StringType,
   TimeType,
   TimestampType,
-  VariantType
+  VariantType,
+  YearMonthIntervalType
 }
 
 import java.util.Locale
@@ -154,6 +156,21 @@ private[snowpark] object DataTypeParser {
     "date" -> DateType,
     "time" -> TimeType,
     "timestamp" -> TimestampType,
+
+    // Interval types — all sub-qualifiers of each family map to the same SDK type
+    "interval day to second" -> DayTimeIntervalType,
+    "interval day to minute" -> DayTimeIntervalType,
+    "interval day to hour" -> DayTimeIntervalType,
+    "interval day" -> DayTimeIntervalType,
+    "interval hour to second" -> DayTimeIntervalType,
+    "interval hour to minute" -> DayTimeIntervalType,
+    "interval hour" -> DayTimeIntervalType,
+    "interval minute to second" -> DayTimeIntervalType,
+    "interval minute" -> DayTimeIntervalType,
+    "interval second" -> DayTimeIntervalType,
+    "interval year to month" -> YearMonthIntervalType,
+    "interval year" -> YearMonthIntervalType,
+    "interval month" -> YearMonthIntervalType,
 
     // Semi-structured types
     "variant" -> VariantType,

--- a/src/main/scala/com/snowflake/snowpark/internal/DataTypeParser.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/DataTypeParser.scala
@@ -171,6 +171,12 @@ private[snowpark] object DataTypeParser {
     "interval year to month" -> YearMonthIntervalType,
     "interval year" -> YearMonthIntervalType,
     "interval month" -> YearMonthIntervalType,
+    // typeName round-trip aliases
+    "daytimeinterval" -> DayTimeIntervalType,
+    "yearmonthinterval" -> YearMonthIntervalType,
+    // JDBC column type names
+    "interval_day_time" -> DayTimeIntervalType,
+    "interval_year_month" -> YearMonthIntervalType,
 
     // Semi-structured types
     "variant" -> VariantType,

--- a/src/main/scala/com/snowflake/snowpark/internal/JavaDataTypeUtils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/JavaDataTypeUtils.scala
@@ -9,6 +9,7 @@ import com.snowflake.snowpark_java.types.{
   DataType => JDataType,
   DataTypes => JDataTypes,
   DateType => JDateType,
+  DayTimeIntervalType => JDayTimeIntervalType,
   DecimalType => JDecimalType,
   DoubleType => JDoubleType,
   FloatType => JFloatType,
@@ -21,7 +22,8 @@ import com.snowflake.snowpark_java.types.{
   StringType => JStringType,
   TimestampType => JTimestampType,
   TimeType => JTimeType,
-  VariantType => JVariantType
+  VariantType => JVariantType,
+  YearMonthIntervalType => JYearMonthIntervalType
 }
 
 object JavaDataTypeUtils {
@@ -47,6 +49,8 @@ object JavaDataTypeUtils {
       case TimestampType => JDataTypes.TimestampType
       case TimeType => JDataTypes.TimeType
       case VariantType => JDataTypes.VariantType
+      case DayTimeIntervalType => JDataTypes.DayTimeIntervalType
+      case YearMonthIntervalType => JDataTypes.YearMonthIntervalType
       case st: StructType =>
         com.snowflake.snowpark_java.types.InternalUtils.createStructType(st)
     }
@@ -72,5 +76,7 @@ object JavaDataTypeUtils {
       case _: JTimestampType => TimestampType
       case _: JTimeType => TimeType
       case _: JVariantType => VariantType
+      case _: JDayTimeIntervalType => DayTimeIntervalType
+      case _: JYearMonthIntervalType => YearMonthIntervalType
     }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/ScalaFunctions.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ScalaFunctions.scala
@@ -51,6 +51,8 @@ object ScalaFunctions {
     case t if t =:= typeOf[java.sql.Date] => true
     case t if t =:= typeOf[java.sql.Time] => true
     case t if t =:= typeOf[java.sql.Timestamp] => true
+    case t if t =:= typeOf[java.time.Duration] => true
+    case t if t =:= typeOf[java.time.Period] => true
     case t if t =:= typeOf[Array[Byte]] => true
     case t if t =:= typeOf[Array[String]] => true
     case t if t =:= typeOf[Array[Variant]] => true

--- a/src/main/scala/com/snowflake/snowpark/internal/ScalaFunctions.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ScalaFunctions.scala
@@ -92,6 +92,8 @@ object ScalaFunctions {
     case t if t =:= typeOf[java.sql.Date] => UdfColumnSchema(DateType)
     case t if t =:= typeOf[java.sql.Time] => UdfColumnSchema(TimeType)
     case t if t =:= typeOf[java.sql.Timestamp] => UdfColumnSchema(TimestampType)
+    case t if t =:= typeOf[java.time.Duration] => UdfColumnSchema(DayTimeIntervalType)
+    case t if t =:= typeOf[java.time.Period] => UdfColumnSchema(YearMonthIntervalType)
     case t if t =:= typeOf[Array[Byte]] => UdfColumnSchema(BinaryType)
     case t if t =:= typeOf[Array[String]] => UdfColumnSchema(ArrayType(StringType))
     case t if t =:= typeOf[Array[Variant]] => UdfColumnSchema(ArrayType(VariantType))

--- a/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
@@ -1172,7 +1172,15 @@ private[snowflake] class SnowflakeResultSetExt(data: SnowflakeResultSetV1) {
         }
       case "DOUBLE" | "BOOLEAN" | "BINARY" | "NUMBER" => value
       case "VARCHAR" | "VARIANT" => value.toString // Text to String
-      case "INTERVAL_DAY_TIME" | "INTERVAL_YEAR_MONTH" => value
+      case "INTERVAL_DAY_TIME" =>
+        val nanos = value.asInstanceOf[Long]
+        val sign = java.lang.Long.signum(nanos)
+        val abs = Math.abs(nanos)
+        val d = java.time.Duration.ofSeconds(abs / 1000000000L, abs % 1000000000L)
+        if (sign < 0) d.negated() else d
+      case "INTERVAL_YEAR_MONTH" =>
+        val months = value.asInstanceOf[Number].intValue()
+        java.time.Period.of(months / 12, months % 12, 0)
       case "DATE" =>
         arrowResultSet.convertToDate(value, null)
       case "TIME" =>

--- a/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
@@ -154,6 +154,8 @@ private[snowpark] object ServerConnection {
         }
       case "GEOGRAPHY" => GeographyType
       case "GEOMETRY" => GeometryType
+      case "INTERVAL_DAY_TIME" => DayTimeIntervalType
+      case "INTERVAL_YEAR_MONTH" => YearMonthIntervalType
       case _ => getTypeFromJDBCType(sqlType, precision, scale, signed)
     }
   }
@@ -378,6 +380,10 @@ private[snowpark] class ServerConnection(
                     case LongType => data.getLong(resultIndex)
                     case TimestampType => data.getTimestamp(resultIndex)
                     case ShortType => data.getShort(resultIndex)
+                    case DayTimeIntervalType =>
+                      data.getObject(resultIndex, classOf[java.time.Duration])
+                    case YearMonthIntervalType =>
+                      data.getObject(resultIndex, classOf[java.time.Period])
                     case GeographyType =>
                       geographyOutputFormat match {
                         case "GeoJSON" => Geography.fromGeoJSON(data.getString(resultIndex))
@@ -1166,6 +1172,7 @@ private[snowflake] class SnowflakeResultSetExt(data: SnowflakeResultSetV1) {
         }
       case "DOUBLE" | "BOOLEAN" | "BINARY" | "NUMBER" => value
       case "VARCHAR" | "VARIANT" => value.toString // Text to String
+      case "INTERVAL_DAY_TIME" | "INTERVAL_YEAR_MONTH" => value
       case "DATE" =>
         arrowResultSet.convertToDate(value, null)
       case "TIME" =>

--- a/src/main/scala/com/snowflake/snowpark/internal/TypeToSchemaConverter.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/TypeToSchemaConverter.scala
@@ -6,6 +6,7 @@ import com.snowflake.snowpark.types._
 import scala.reflect.runtime.universe.{MethodSymbol, Type, TypeTag, typeOf}
 import java.math.{BigDecimal => JavaBigDecimal}
 import java.sql.{Date, Time, Timestamp}
+import java.time.{Duration, Period}
 import java.lang.{
   Boolean => JavaBoolean,
   Byte => JavaByte,
@@ -87,6 +88,8 @@ object TypeToSchemaConverter {
       case t if t =:= typeOf[Date] => (DateType, true)
       case t if t =:= typeOf[Timestamp] => (TimestampType, true)
       case t if t =:= typeOf[Time] => (TimeType, true)
+      case t if t =:= typeOf[Duration] => (DayTimeIntervalType, true)
+      case t if t =:= typeOf[Period] => (YearMonthIntervalType, true)
       case t if t =:= typeOf[Boolean] => (BooleanType, false)
       case t if t =:= typeOf[JavaBoolean] => (BooleanType, true)
       case t if t =:= typeOf[Byte] => (ByteType, false)

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/DataTypeMapper.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/DataTypeMapper.scala
@@ -172,22 +172,12 @@ object DataTypeMapper {
       }
     }
 
+  // Only called from toSqlAvoidOffset which guards on IntegralType, so interval types never reach
+  // this path. Interval literals go through toSql -> durationToSql / periodToSql instead.
   private[analyzer] def toSqlWithoutCast(value: Any, dataType: DataType): String =
     dataType match {
       case _ if value == null => "NULL"
       case StringType => s"""'$value'"""
-      case DayTimeIntervalType =>
-        value match {
-          case d: Duration => durationToSql(d)
-          case s: String => s
-          case other => other.toString
-        }
-      case YearMonthIntervalType =>
-        value match {
-          case p: Period => periodToSql(p)
-          case s: String => s
-          case other => other.toString
-        }
       case _ => value.toString
     }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/DataTypeMapper.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/DataTypeMapper.scala
@@ -2,6 +2,7 @@ package com.snowflake.snowpark.internal.analyzer
 import com.snowflake.snowpark.internal.Utils
 
 import java.sql.{Date, Timestamp}
+import java.time.{Duration, Period}
 import java.util.TimeZone
 import java.math.{BigDecimal => JBigDecimal}
 
@@ -21,6 +22,55 @@ object DataTypeMapper {
       .replaceAll("\\\\", "\\\\\\\\")
       .replaceAll("'", "''")
       .replaceAll("\n", "\\\\n") + "'"
+
+  /**
+   * Format a [[Duration]] as a Snowflake day-time interval string (without the INTERVAL keyword),
+   * suitable for CAST(... AS INTERVAL DAY TO SECOND).
+   *
+   * Uses explicit day/h/m/s/nano breakdown because the library still targets Java 8
+   * ([[Duration.toHoursPart]] and related APIs are Java 9+).
+   */
+  private[snowpark] def formatDuration(duration: Duration): String = {
+    val negative = duration.isNegative
+    val abs = duration.abs()
+    val days = abs.toDays
+    val remSeconds = abs.minusDays(days).getSeconds
+    val hours = remSeconds / 3600
+    val minutes = (remSeconds % 3600) / 60
+    val seconds = remSeconds % 60
+    val nanos = abs.getNano
+    val sign = if (negative) "-" else ""
+    f"$sign$days $hours%02d:$minutes%02d:$seconds%02d.$nanos%09d"
+  }
+
+  /**
+   * Convert a [[Duration]] to a Snowflake INTERVAL DAY TO SECOND SQL literal.
+   */
+  private[analyzer] def durationToSql(duration: Duration): String =
+    s"INTERVAL '${formatDuration(duration)}' DAY TO SECOND"
+
+  /**
+   * Format a [[Period]] as a Snowflake year-month interval string (without the INTERVAL keyword).
+   * Days must be zero — year-month intervals do not carry a day component.
+   */
+  private[snowpark] def formatPeriod(period: Period): String = {
+    if (period.getDays != 0) {
+      throw new UnsupportedOperationException(
+        s"Year-month interval Period must have days=0, got: $period")
+    }
+    // normalized() folds months into years (|months| < 12) with a consistent sign.
+    val normalized = period.normalized()
+    val negative = normalized.isNegative
+    val abs = if (negative) normalized.negated() else normalized
+    val sign = if (negative) "-" else ""
+    s"$sign${abs.getYears}-${abs.getMonths}"
+  }
+
+  /**
+   * Convert a [[Period]] to a Snowflake INTERVAL YEAR TO MONTH SQL literal.
+   */
+  private[analyzer] def periodToSql(period: Period): String =
+    s"INTERVAL '${formatPeriod(period)}' YEAR TO MONTH"
 
   /*
    * Convert a value with DataType to a snowflake compatible sql
@@ -42,6 +92,8 @@ object DataTypeMapper {
           case (_, DoubleType) if value == null => "NULL :: double"
           case (_, BooleanType) if value == null => "NULL :: boolean"
           case (_, BinaryType) if value == null => "NULL :: binary"
+          case (_, DayTimeIntervalType) if value == null => "NULL :: INTERVAL DAY TO SECOND"
+          case (_, YearMonthIntervalType) if value == null => "NULL :: INTERVAL YEAR TO MONTH"
           case _ if value == null => "NULL"
           case (v: String, StringType) => stringToSql(v)
           case (v: Byte, ByteType) => v + s" :: tinyint"
@@ -78,6 +130,12 @@ object DataTypeMapper {
                 .format(new Timestamp(v / MICROS_PER_MILLIS), TimeZone.getDefault, 3)}'"
           case (v: Array[Byte], BinaryType) =>
             s"'${DatatypeConverter.printHexBinary(v)}' :: binary"
+          case (v: Duration, DayTimeIntervalType) => durationToSql(v)
+          case (v: Period, YearMonthIntervalType) => periodToSql(v)
+          case (v: String, DayTimeIntervalType) =>
+            s"${stringToSql(v)} :: INTERVAL DAY TO SECOND"
+          case (v: String, YearMonthIntervalType) =>
+            s"${stringToSql(v)} :: INTERVAL YEAR TO MONTH"
           case _ =>
             throw new UnsupportedOperationException(
               s"Unsupported datatype by ToSql: ${value.getClass.getName} => $dataType")
@@ -102,6 +160,8 @@ object DataTypeMapper {
         case DateType => "date('2020-9-16')"
         case TimeType => "to_time('04:15:29.999')"
         case TimestampType => "to_timestamp_ntz('2020-09-16 06:30:00')"
+        case DayTimeIntervalType => "INTERVAL '1 01:01:01.0001' DAY TO SECOND"
+        case YearMonthIntervalType => "INTERVAL '1-0' YEAR TO MONTH"
         case _: ArrayType => "[]::" + convertToSFType(dataType)
         case _: MapType => "{}::" + convertToSFType(dataType)
         case VariantType => "to_variant(0)"
@@ -116,6 +176,18 @@ object DataTypeMapper {
     dataType match {
       case _ if value == null => "NULL"
       case StringType => s"""'$value'"""
+      case DayTimeIntervalType =>
+        value match {
+          case d: Duration => durationToSql(d)
+          case s: String => s
+          case other => other.toString
+        }
+      case YearMonthIntervalType =>
+        value match {
+          case p: Period => periodToSql(p)
+          case s: String => s
+          case other => other.toString
+        }
       case _ => value.toString
     }
 }

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/Literal.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/Literal.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark.internal.ErrorMessage
 import com.snowflake.snowpark.types._
 import java.math.{BigDecimal => JavaBigDecimal}
 import java.sql.{Date, Timestamp}
-import java.time.{Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate, Period}
 
 import scala.math.BigDecimal
 
@@ -37,6 +37,8 @@ private[snowpark] object Literal {
     case ld: LocalDate => Literal(DateTimeUtils.localDateToDays(ld), Option(DateType))
     case d: Date => Literal(DateTimeUtils.javaDateToDays(d), Option(DateType))
     case a: Array[Byte] => Literal(a, Option(BinaryType))
+    case d: Duration => Literal(d, Option(DayTimeIntervalType))
+    case p: Period => Literal(p, Option(YearMonthIntervalType))
     case null => Literal(null, None)
     case v: Literal => v
     case _ =>

--- a/src/main/scala/com/snowflake/snowpark/types/DayTimeIntervalType.scala
+++ b/src/main/scala/com/snowflake/snowpark/types/DayTimeIntervalType.scala
@@ -1,0 +1,12 @@
+package com.snowflake.snowpark.types
+
+/**
+ * Day-time interval data type. Mapped to INTERVAL DAY TO SECOND Snowflake data type.
+ *
+ * At the UDF/sproc boundary, day-time interval values are transmitted as Arrow MonthDayNano
+ * ({months=0, days=D, nanoseconds=N}) and surfaced to Java/Scala handlers as
+ * [[java.time.Duration]].
+ *
+ * @since 1.14.0
+ */
+object DayTimeIntervalType extends AtomicType

--- a/src/main/scala/com/snowflake/snowpark/types/YearMonthIntervalType.scala
+++ b/src/main/scala/com/snowflake/snowpark/types/YearMonthIntervalType.scala
@@ -1,0 +1,12 @@
+package com.snowflake.snowpark.types
+
+/**
+ * Year-month interval data type. Mapped to INTERVAL YEAR TO MONTH Snowflake data type.
+ *
+ * At the UDF/sproc boundary, year-month interval values are transmitted as Arrow MonthDayNano
+ * ({months=M, days=0, nanoseconds=0}) and surfaced to Java/Scala handlers as
+ * [[java.time.Period]].
+ *
+ * @since 1.14.0
+ */
+object YearMonthIntervalType extends AtomicType

--- a/src/main/scala/com/snowflake/snowpark/types/YearMonthIntervalType.scala
+++ b/src/main/scala/com/snowflake/snowpark/types/YearMonthIntervalType.scala
@@ -4,8 +4,7 @@ package com.snowflake.snowpark.types
  * Year-month interval data type. Mapped to INTERVAL YEAR TO MONTH Snowflake data type.
  *
  * At the UDF/sproc boundary, year-month interval values are transmitted as Arrow MonthDayNano
- * ({months=M, days=0, nanoseconds=0}) and surfaced to Java/Scala handlers as
- * [[java.time.Period]].
+ * ({months=M, days=0, nanoseconds=0}) and surfaced to Java/Scala handlers as [[java.time.Period]].
  *
  * @since 1.14.0
  */

--- a/src/main/scala/com/snowflake/snowpark/types/package.scala
+++ b/src/main/scala/com/snowflake/snowpark/types/package.scala
@@ -29,6 +29,8 @@ package object types {
       case GeographyType => "Geography"
       case GeometryType => "Geometry"
       case VariantType => "Variant"
+      case DayTimeIntervalType => classOf[java.time.Duration].getCanonicalName
+      case YearMonthIntervalType => classOf[java.time.Period].getCanonicalName
       // StructType is only used for defining schema
       // case StructType(_) => // Not Supported
       case _ =>
@@ -81,6 +83,8 @@ package object types {
       case VariantType => "VARIANT"
       case GeographyType => "GEOGRAPHY"
       case GeometryType => "GEOMETRY"
+      case DayTimeIntervalType => "INTERVAL DAY TO SECOND"
+      case YearMonthIntervalType => "INTERVAL YEAR TO MONTH"
       case StructType(_) => "OBJECT"
       case _ =>
         throw new UnsupportedOperationException(s"Unsupported data type: ${dataType.typeName}")
@@ -105,6 +109,8 @@ package object types {
       case "com.snowflake.snowpark_java.types.Variant" => VariantType
       case "java.lang.String[]" => ArrayType(StringType)
       case "com.snowflake.snowpark_java.types.Variant[]" => ArrayType(VariantType)
+      case "java.time.Duration" => DayTimeIntervalType
+      case "java.time.Period" => YearMonthIntervalType
       case "java.util.Map" => throw ErrorMessage.UDF_CANNOT_INFER_MAP_TYPES()
       case _ => throw new UnsupportedOperationException(s"Unsupported data type: $className")
     }

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
@@ -3,6 +3,11 @@ package com.snowflake.snowpark_test;
 import static org.junit.Assert.assertThrows;
 
 import com.snowflake.snowpark_java.*;
+import com.snowflake.snowpark_java.types.DataTypes;
+import com.snowflake.snowpark_java.types.StructField;
+import com.snowflake.snowpark_java.types.StructType;
+import java.time.Duration;
+import java.time.Period;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -412,5 +417,18 @@ public class JavaDataFrameSuite extends TestBase {
 
     // Negative test: column doesn't exist
     assertThrows(SnowflakeSQLException.class, () -> df.sort("non_existent_column").collect());
+  }
+
+  @Test
+  public void createDataFrameWithIntervalSchema() {
+    StructType schema =
+        StructType.create(
+            new StructField("dt", DataTypes.DayTimeIntervalType),
+            new StructField("ym", DataTypes.YearMonthIntervalType));
+    Row[] data = {
+      Row.create(Duration.ofDays(5).plusHours(12), Period.of(1, 6, 0)), Row.create(null, null)
+    };
+    DataFrame df = getSession().createDataFrame(data, schema);
+    checkAnswer(df, data);
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
@@ -42,6 +42,10 @@ public class JavaDataTypesSuite {
         .equals(com.snowflake.snowpark.types.TimeType$.MODULE$);
     assert JavaDataTypeUtils.javaTypeToScalaType(DataTypes.VariantType)
         .equals(com.snowflake.snowpark.types.VariantType$.MODULE$);
+    assert JavaDataTypeUtils.javaTypeToScalaType(DataTypes.DayTimeIntervalType)
+        .equals(com.snowflake.snowpark.types.DayTimeIntervalType$.MODULE$);
+    assert JavaDataTypeUtils.javaTypeToScalaType(DataTypes.YearMonthIntervalType)
+        .equals(com.snowflake.snowpark.types.YearMonthIntervalType$.MODULE$);
 
     assert JavaDataTypeUtils.javaTypeToScalaType(
             DataTypes.createDecimalType(DecimalType.MAX_PRECISION, DecimalType.MAX_SCALE))

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataTypesSuite.java
@@ -118,6 +118,12 @@ public class JavaDataTypesSuite {
         .equals(DataTypes.TimeType);
     assert JavaDataTypeUtils.scalaTypeToJavaType(com.snowflake.snowpark.types.VariantType$.MODULE$)
         .equals(DataTypes.VariantType);
+    assert JavaDataTypeUtils.scalaTypeToJavaType(
+            com.snowflake.snowpark.types.DayTimeIntervalType$.MODULE$)
+        .equals(DataTypes.DayTimeIntervalType);
+    assert JavaDataTypeUtils.scalaTypeToJavaType(
+            com.snowflake.snowpark.types.YearMonthIntervalType$.MODULE$)
+        .equals(DataTypes.YearMonthIntervalType);
 
     assert JavaDataTypeUtils.scalaTypeToJavaType(
             new com.snowflake.snowpark.types.DecimalType(38, 38))
@@ -170,6 +176,8 @@ public class JavaDataTypesSuite {
     assert DataTypes.TimestampType.typeName().equals("TimestampType");
     assert DataTypes.TimeType.typeName().equals("TimeType");
     assert DataTypes.VariantType.typeName().equals("VariantType");
+    assert DataTypes.DayTimeIntervalType.typeName().equals("DayTimeIntervalType");
+    assert DataTypes.YearMonthIntervalType.typeName().equals("YearMonthIntervalType");
     assert DataTypes.createArrayType(DataTypes.IntegerType).typeName().equals("ArrayType");
     assert DataTypes.createMapType(DataTypes.StringType, DataTypes.DoubleType)
         .typeName()
@@ -193,6 +201,10 @@ public class JavaDataTypesSuite {
     assert DataTypes.TimestampType.typeName().equals(DataTypes.TimestampType.toString());
     assert DataTypes.TimeType.typeName().equals(DataTypes.TimeType.toString());
     assert DataTypes.VariantType.typeName().equals(DataTypes.VariantType.toString());
+    assert DataTypes.DayTimeIntervalType.typeName()
+        .equals(DataTypes.DayTimeIntervalType.toString());
+    assert DataTypes.YearMonthIntervalType.typeName()
+        .equals(DataTypes.YearMonthIntervalType.toString());
     assert DataTypes.createDecimalType(20, 10).toString().equals("Decimal(20, 10)");
     assert DataTypes.createArrayType(DataTypes.IntegerType)
         .toString()

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -3657,6 +3657,13 @@ public class JavaFunctionSuite extends TestBase {
     checkAnswer(
         getSession().sql("SELECT 1").select(Functions.lit(Period.ofMonths(14))),
         new Row[] {Row.create(Period.of(1, 2, 0))});
+    // negative year-month
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Period.of(-1, -6, 0))),
+        new Row[] {Row.create(Period.of(-1, -6, 0))});
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Period.ofMonths(-14))),
+        new Row[] {Row.create(Period.of(-1, -2, 0))});
   }
 
   @Test

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -9,6 +9,8 @@ import com.snowflake.snowpark_java.types.StructType;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Period;
 import java.util.Arrays;
 import net.snowflake.client.jdbc.SnowflakeSQLException;
 import org.junit.Assert;
@@ -3627,6 +3629,27 @@ public class JavaFunctionSuite extends TestBase {
           checkAnswer(df.select(Functions.from_utc_timestamp(df.col("a"))), expected);
         },
         getSession());
+  }
+
+  @Test
+  public void litIntervalTypes() {
+    // Duration: INTERVAL '...' DAY TO SECOND round-trip
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Duration.ofDays(5))),
+        new Row[] {Row.create(Duration.ofDays(5))});
+    checkAnswer(
+        getSession()
+            .sql("SELECT 1")
+            .select(
+                Functions.lit(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))),
+        new Row[] {Row.create(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))});
+    // Period: INTERVAL '...' YEAR TO MONTH round-trip; ofMonths(14) normalizes to 1-2
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Period.of(1, 6, 0))),
+        new Row[] {Row.create(Period.of(1, 6, 0))});
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Period.ofMonths(14))),
+        new Row[] {Row.create(Period.of(1, 2, 0))});
   }
 
   @Test

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -3643,6 +3643,13 @@ public class JavaFunctionSuite extends TestBase {
             .select(
                 Functions.lit(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))),
         new Row[] {Row.create(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))});
+    // overflow: hours > 23 and minutes > 59 exercise the carry/remainder logic in formatDuration
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Duration.ofHours(25))),
+        new Row[] {Row.create(Duration.ofHours(25))});
+    checkAnswer(
+        getSession().sql("SELECT 1").select(Functions.lit(Duration.ofMinutes(90))),
+        new Row[] {Row.create(Duration.ofMinutes(90))});
     // Period: INTERVAL '...' YEAR TO MONTH round-trip; ofMonths(14) normalizes to 1-2
     checkAnswer(
         getSession().sql("SELECT 1").select(Functions.lit(Period.of(1, 6, 0))),

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
@@ -234,7 +234,6 @@ public class JavaUDFSuite extends UDFTestBase {
             DataTypes.YearMonthIntervalType,
             DataTypes.YearMonthIntervalType);
     checkAnswer(
-        df.select(udf.apply(df.col("m"))),
-        new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
+        df.select(udf.apply(df.col("m"))), new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
@@ -215,45 +215,42 @@ public class JavaUDFSuite extends UDFTestBase {
 
   @Test
   public void udfOfDuration() {
-    // ACCOUNT_LINEAGE — not session-settable; require already enabled.
-    assumeIntervalUdfEnabled();
-    DataFrame df = getSession().sql("SELECT INTERVAL '5' DAY AS d");
-    UserDefinedFunction udf =
-        Functions.udf(
-            (java.time.Duration d) -> d.plusDays(1),
-            DataTypes.DayTimeIntervalType,
-            DataTypes.DayTimeIntervalType);
-    checkAnswer(
-        df.select(udf.apply(df.col("d"))), new Row[] {Row.create(java.time.Duration.ofDays(6))});
+    withIntervalUdfEnabled(
+        () -> {
+          DataFrame df = getSession().sql("SELECT INTERVAL '5' DAY AS d");
+          UserDefinedFunction udf =
+              Functions.udf(
+                  (java.time.Duration d) -> d.plusDays(1),
+                  DataTypes.DayTimeIntervalType,
+                  DataTypes.DayTimeIntervalType);
+          checkAnswer(
+              df.select(udf.apply(df.col("d"))),
+              new Row[] {Row.create(java.time.Duration.ofDays(6))});
+        });
   }
 
   @Test
   public void udfOfPeriod() {
-    assumeIntervalUdfEnabled();
-    DataFrame df = getSession().sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m");
-    UserDefinedFunction udf =
-        Functions.udf(
-            (java.time.Period p) -> p.plusYears(1),
-            DataTypes.YearMonthIntervalType,
-            DataTypes.YearMonthIntervalType);
-    checkAnswer(
-        df.select(udf.apply(df.col("m"))), new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
+    withIntervalUdfEnabled(
+        () -> {
+          DataFrame df = getSession().sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m");
+          UserDefinedFunction udf =
+              Functions.udf(
+                  (java.time.Period p) -> p.plusYears(1),
+                  DataTypes.YearMonthIntervalType,
+                  DataTypes.YearMonthIntervalType);
+          checkAnswer(
+              df.select(udf.apply(df.col("m"))),
+              new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
+        });
   }
 
-  private void assumeIntervalUdfEnabled() {
-    Row[] rows =
-        getSession()
-            .sql("SHOW PARAMETERS LIKE 'ENABLE_INTERVAL_TYPES_IN_UDF' IN ACCOUNT")
-            .collect();
-    boolean enabled = false;
-    for (Row r : rows) {
-      String v = r.getString(1);
-      if (v != null && v.equalsIgnoreCase("true")) {
-        enabled = true;
-        break;
-      }
+  private void withIntervalUdfEnabled(Runnable body) {
+    getSession().sql("alter session set ENABLE_INTERVAL_TYPES_IN_UDF = true").collect();
+    try {
+      body.run();
+    } finally {
+      getSession().sql("alter session unset ENABLE_INTERVAL_TYPES_IN_UDF").collect();
     }
-    org.junit.Assume.assumeTrue(
-        "ENABLE_INTERVAL_TYPES_IN_UDF must be TRUE at account level", enabled);
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
@@ -212,4 +212,48 @@ public class JavaUDFSuite extends UDFTestBase {
     Row[] result = {Row.create(100), Row.create((Object) null), Row.create(9)};
     checkAnswer(df.select(udf.apply(df.col("col1"), df.col("col2"))), result);
   }
+
+  @Test
+  public void udfOfDuration() {
+    // ACCOUNT_LINEAGE — not session-settable; require already enabled.
+    assumeIntervalUdfEnabled();
+    DataFrame df = getSession().sql("SELECT INTERVAL '5' DAY AS d");
+    UserDefinedFunction udf =
+        Functions.udf(
+            (java.time.Duration d) -> d.plusDays(1),
+            DataTypes.DayTimeIntervalType,
+            DataTypes.DayTimeIntervalType);
+    checkAnswer(
+        df.select(udf.apply(df.col("d"))), new Row[] {Row.create(java.time.Duration.ofDays(6))});
+  }
+
+  @Test
+  public void udfOfPeriod() {
+    assumeIntervalUdfEnabled();
+    DataFrame df = getSession().sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m");
+    UserDefinedFunction udf =
+        Functions.udf(
+            (java.time.Period p) -> p.plusYears(1),
+            DataTypes.YearMonthIntervalType,
+            DataTypes.YearMonthIntervalType);
+    checkAnswer(
+        df.select(udf.apply(df.col("m"))), new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
+  }
+
+  private void assumeIntervalUdfEnabled() {
+    Row[] rows =
+        getSession()
+            .sql("SHOW PARAMETERS LIKE 'ENABLE_INTERVAL_TYPES_IN_UDF' IN ACCOUNT")
+            .collect();
+    boolean enabled = false;
+    for (Row r : rows) {
+      String v = r.getString(1);
+      if (v != null && v.equalsIgnoreCase("true")) {
+        enabled = true;
+        break;
+      }
+    }
+    org.junit.Assume.assumeTrue(
+        "ENABLE_INTERVAL_TYPES_IN_UDF must be TRUE at account level", enabled);
+  }
 }

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDFSuite.java
@@ -215,42 +215,26 @@ public class JavaUDFSuite extends UDFTestBase {
 
   @Test
   public void udfOfDuration() {
-    withIntervalUdfEnabled(
-        () -> {
-          DataFrame df = getSession().sql("SELECT INTERVAL '5' DAY AS d");
-          UserDefinedFunction udf =
-              Functions.udf(
-                  (java.time.Duration d) -> d.plusDays(1),
-                  DataTypes.DayTimeIntervalType,
-                  DataTypes.DayTimeIntervalType);
-          checkAnswer(
-              df.select(udf.apply(df.col("d"))),
-              new Row[] {Row.create(java.time.Duration.ofDays(6))});
-        });
+    DataFrame df = getSession().sql("SELECT INTERVAL '5' DAY AS d");
+    UserDefinedFunction udf =
+        Functions.udf(
+            (java.time.Duration d) -> d.plusDays(1),
+            DataTypes.DayTimeIntervalType,
+            DataTypes.DayTimeIntervalType);
+    checkAnswer(
+        df.select(udf.apply(df.col("d"))), new Row[] {Row.create(java.time.Duration.ofDays(6))});
   }
 
   @Test
   public void udfOfPeriod() {
-    withIntervalUdfEnabled(
-        () -> {
-          DataFrame df = getSession().sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m");
-          UserDefinedFunction udf =
-              Functions.udf(
-                  (java.time.Period p) -> p.plusYears(1),
-                  DataTypes.YearMonthIntervalType,
-                  DataTypes.YearMonthIntervalType);
-          checkAnswer(
-              df.select(udf.apply(df.col("m"))),
-              new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
-        });
-  }
-
-  private void withIntervalUdfEnabled(Runnable body) {
-    getSession().sql("alter session set ENABLE_INTERVAL_TYPES_IN_UDF = true").collect();
-    try {
-      body.run();
-    } finally {
-      getSession().sql("alter session unset ENABLE_INTERVAL_TYPES_IN_UDF").collect();
-    }
+    DataFrame df = getSession().sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m");
+    UserDefinedFunction udf =
+        Functions.udf(
+            (java.time.Period p) -> p.plusYears(1),
+            DataTypes.YearMonthIntervalType,
+            DataTypes.YearMonthIntervalType);
+    checkAnswer(
+        df.select(udf.apply(df.col("m"))),
+        new Row[] {Row.create(java.time.Period.of(2, 2, 0))});
   }
 }

--- a/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
+++ b/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
@@ -24,7 +24,8 @@ public abstract class UDFTestBase extends TestFunctions {
       newSession
           .sql("alter session set ENABLE_FIX_SNOW_3011194_SCALA_VERSIONED_HANDLER_NAMES=true")
           .collect();
-    } catch (Exception ignored) {}
+    } catch (Exception ignored) {
+    }
     if (JavaUtils.snowparkScalaCompatVersion().equals("2.13")) {
       newSession.sql("alter session set ENABLE_SCALA_UDF_RUNTIME_2_13=true").collect();
     }

--- a/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
+++ b/src/test/java/com/snowflake/snowpark_test/UDFTestBase.java
@@ -20,6 +20,11 @@ public abstract class UDFTestBase extends TestFunctions {
 
   protected Session createSession() {
     Session newSession = Session.builder().configFile(defaultProfile).create();
+    try {
+      newSession
+          .sql("alter session set ENABLE_FIX_SNOW_3011194_SCALA_VERSIONED_HANDLER_NAMES=true")
+          .collect();
+    } catch (Exception ignored) {}
     if (JavaUtils.snowparkScalaCompatVersion().equals("2.13")) {
       newSession.sql("alter session set ENABLE_SCALA_UDF_RUNTIME_2_13=true").collect();
     }

--- a/src/test/scala/com/snowflake/snowpark/DataTypeParserSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/DataTypeParserSuite.scala
@@ -8,6 +8,7 @@ import com.snowflake.snowpark.types.{
   ByteType,
   DataType,
   DateType,
+  DayTimeIntervalType,
   DecimalType,
   DoubleType,
   FloatType,
@@ -20,7 +21,8 @@ import com.snowflake.snowpark.types.{
   StringType,
   TimeType,
   TimestampType,
-  VariantType
+  VariantType,
+  YearMonthIntervalType
 }
 import com.snowflake.snowpark.internal.DataTypeParser.{
   EmptyInput,
@@ -82,7 +84,22 @@ class DataTypeParserSuite extends AnyFunSuite with TableDrivenPropertyChecks {
       ("object", MapType(StringType, VariantType)),
       ("boolean", BooleanType),
       ("geography", GeographyType),
-      ("geometry", GeometryType))
+      ("geometry", GeometryType),
+      // Interval types — all day-time sub-qualifiers
+      ("interval day to second", DayTimeIntervalType),
+      ("interval day to minute", DayTimeIntervalType),
+      ("interval day to hour", DayTimeIntervalType),
+      ("interval day", DayTimeIntervalType),
+      ("interval hour to second", DayTimeIntervalType),
+      ("interval hour to minute", DayTimeIntervalType),
+      ("interval hour", DayTimeIntervalType),
+      ("interval minute to second", DayTimeIntervalType),
+      ("interval minute", DayTimeIntervalType),
+      ("interval second", DayTimeIntervalType),
+      // Interval types — all year-month sub-qualifiers
+      ("interval year to month", YearMonthIntervalType),
+      ("interval year", YearMonthIntervalType),
+      ("interval month", YearMonthIntervalType))
 
     forAll(simpleTypes) { (input: String, expected: DataType) =>
       expectRight(input, expected)

--- a/src/test/scala/com/snowflake/snowpark/DataTypeParserSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/DataTypeParserSuite.scala
@@ -99,7 +99,12 @@ class DataTypeParserSuite extends AnyFunSuite with TableDrivenPropertyChecks {
       // Interval types — all year-month sub-qualifiers
       ("interval year to month", YearMonthIntervalType),
       ("interval year", YearMonthIntervalType),
-      ("interval month", YearMonthIntervalType))
+      ("interval month", YearMonthIntervalType),
+      // typeName / JDBC aliases
+      ("DayTimeInterval", DayTimeIntervalType),
+      ("YearMonthInterval", YearMonthIntervalType),
+      ("INTERVAL_DAY_TIME", DayTimeIntervalType),
+      ("INTERVAL_YEAR_MONTH", YearMonthIntervalType))
 
     forAll(simpleTypes) { (input: String, expected: DataType) =>
       expectRight(input, expected)

--- a/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
+++ b/src/test/scala/com/snowflake/snowpark/SNTestBase.scala
@@ -89,6 +89,11 @@ trait SNTestBase extends AnyFunSuite with BeforeAndAfterAll with SFTestUtils wit
       .configFile(defaultProfile)
       .configs(configs.toMap)
       .create
+    try {
+      runQuery(
+        "alter session set ENABLE_FIX_SNOW_3011194_SCALA_VERSIONED_HANDLER_NAMES=true",
+        session)
+    } catch { case _: Exception => }
     session
   }
 

--- a/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/internal/analyzer/SqlInjectionSuite.scala
@@ -417,4 +417,56 @@ class SqlInjectionSuite extends AnyFunSuite {
     assert(DataTypeMapper.toSql(-1, Some(IntegerType)) == "-1 :: int")
     assert(DataTypeMapper.toSql(Int.MaxValue, Some(IntegerType)) == s"${Int.MaxValue} :: int")
   }
+
+  test("toSql renders Duration as INTERVAL DAY TO SECOND") {
+    import java.time.Duration
+    import com.snowflake.snowpark.types.DayTimeIntervalType
+    assert(
+      DataTypeMapper.toSql(Duration.ofDays(5), Some(DayTimeIntervalType)) ==
+        "INTERVAL '5 00:00:00.000000000' DAY TO SECOND")
+    assert(
+      DataTypeMapper.toSql(Duration.ofDays(2).plusHours(12), Some(DayTimeIntervalType)) ==
+        "INTERVAL '2 12:00:00.000000000' DAY TO SECOND")
+    assert(
+      DataTypeMapper.toSql(Duration.ofDays(-3), Some(DayTimeIntervalType)) ==
+        "INTERVAL '-3 00:00:00.000000000' DAY TO SECOND")
+    assert(
+      DataTypeMapper.toSql(null, Some(DayTimeIntervalType)) == "NULL :: INTERVAL DAY TO SECOND")
+  }
+
+  test("toSql renders Period as INTERVAL YEAR TO MONTH") {
+    import java.time.Period
+    import com.snowflake.snowpark.types.YearMonthIntervalType
+    assert(
+      DataTypeMapper.toSql(Period.of(1, 2, 0), Some(YearMonthIntervalType)) ==
+        "INTERVAL '1-2' YEAR TO MONTH")
+    assert(
+      DataTypeMapper.toSql(Period.ofMonths(14), Some(YearMonthIntervalType)) ==
+        "INTERVAL '1-2' YEAR TO MONTH")
+    assert(
+      DataTypeMapper.toSql(Period.of(0, -3, 0), Some(YearMonthIntervalType)) ==
+        "INTERVAL '-0-3' YEAR TO MONTH")
+    assert(
+      DataTypeMapper.toSql(null, Some(YearMonthIntervalType)) ==
+        "NULL :: INTERVAL YEAR TO MONTH")
+    intercept[UnsupportedOperationException] {
+      DataTypeMapper.toSql(Period.of(1, 0, 5), Some(YearMonthIntervalType))
+    }
+  }
+
+  test("schemaExpression for interval types") {
+    import com.snowflake.snowpark.types.{DayTimeIntervalType, YearMonthIntervalType}
+    assert(
+      DataTypeMapper.schemaExpression(DayTimeIntervalType, isNullable = true) ==
+        "NULL :: INTERVAL DAY TO SECOND")
+    assert(
+      DataTypeMapper.schemaExpression(YearMonthIntervalType, isNullable = true) ==
+        "NULL :: INTERVAL YEAR TO MONTH")
+    assert(
+      DataTypeMapper.schemaExpression(DayTimeIntervalType, isNullable = false) ==
+        "INTERVAL '1 01:01:01.0001' DAY TO SECOND")
+    assert(
+      DataTypeMapper.schemaExpression(YearMonthIntervalType, isNullable = false) ==
+        "INTERVAL '1-0' YEAR TO MONTH")
+  }
 }

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
@@ -7,6 +7,7 @@ import com.snowflake.snowpark.types._
 import net.snowflake.client.jdbc.SnowflakeSQLException
 import org.scalatest.BeforeAndAfterEach
 import java.sql.{Date, Time, Timestamp}
+import java.time.{Duration, Period}
 import scala.util.Random
 
 trait DataFrameSuite extends TestData with BeforeAndAfterEach {
@@ -1406,6 +1407,14 @@ trait DataFrameSuite extends TestData with BeforeAndAfterEach {
               |}""".stripMargin)),
         Row(null, null, null, null, null))
     checkAnswer(df, expected)
+  }
+
+  test("createDataFrame with given schema: interval types") {
+    val schema = StructType(
+      Seq(StructField("dt", DayTimeIntervalType), StructField("ym", YearMonthIntervalType)))
+    val data = Seq(Row(Duration.ofDays(5).plusHours(12), Period.of(1, 6, 0)), Row(null, null))
+    val df = session.createDataFrame(data, schema)
+    checkAnswer(df, data)
   }
 
   test("variant in array and map") {

--- a/src/test/scala/com/snowflake/snowpark_test/DataTypeSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataTypeSuite.scala
@@ -571,6 +571,22 @@ class DataTypeSuite extends SNTestBase {
     }
   }
 
+  test("DayTimeIntervalType") {
+    assert(DayTimeIntervalType.isInstanceOf[DataType])
+    assert(TestUtils.isAtomicType(DayTimeIntervalType))
+    assert(DayTimeIntervalType.typeName == DayTimeIntervalType.toString)
+    assert(DayTimeIntervalType.typeName == "DayTimeInterval")
+    assert(convertToSFType(DayTimeIntervalType) == "INTERVAL DAY TO SECOND")
+  }
+
+  test("YearMonthIntervalType") {
+    assert(YearMonthIntervalType.isInstanceOf[DataType])
+    assert(TestUtils.isAtomicType(YearMonthIntervalType))
+    assert(YearMonthIntervalType.typeName == YearMonthIntervalType.toString)
+    assert(YearMonthIntervalType.typeName == "YearMonthInterval")
+    assert(convertToSFType(YearMonthIntervalType) == "INTERVAL YEAR TO MONTH")
+  }
+
   test("Variant containing word null in the text") {
     import session.implicits._
     var variant = new Variant("null string starts with null")

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -32,6 +32,13 @@ trait FunctionSuite extends TestData {
         .sql("SELECT 1")
         .select(lit(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))),
       Seq(Row(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))))
+    // overflow: hours > 23 and minutes > 59 exercise the carry/remainder logic in formatDuration
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Duration.ofHours(25))),
+      Seq(Row(Duration.ofHours(25))))
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Duration.ofMinutes(90))),
+      Seq(Row(Duration.ofMinutes(90))))
     // Period: INTERVAL '...' YEAR TO MONTH round-trip; ofMonths(14) normalizes to 1-2
     checkAnswer(
       session.sql("SELECT 1").select(lit(Period.of(1, 6, 0))),

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -46,6 +46,13 @@ trait FunctionSuite extends TestData {
     checkAnswer(
       session.sql("SELECT 1").select(lit(Period.ofMonths(14))),
       Seq(Row(Period.of(1, 2, 0))))
+    // negative year-month
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Period.of(-1, -6, 0))),
+      Seq(Row(Period.of(-1, -6, 0))))
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Period.ofMonths(-14))),
+      Seq(Row(Period.of(-1, -2, 0))))
   }
 
   test("approx count distinct") {

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -8,6 +8,7 @@ import com.snowflake.snowpark.types._
 import net.snowflake.client.jdbc.SnowflakeSQLException
 
 import java.sql.{Date, Time, Timestamp}
+import java.time.{Duration, Period}
 
 trait FunctionSuite extends TestData {
   import session.implicits._
@@ -19,6 +20,25 @@ trait FunctionSuite extends TestData {
 
   test("lit") {
     checkAnswer(testData1.select(lit(1)), Seq(Row(1), Row(1)))
+  }
+
+  test("lit - interval types") {
+    // Duration: INTERVAL '...' DAY TO SECOND round-trip
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Duration.ofDays(5))),
+      Seq(Row(Duration.ofDays(5))))
+    checkAnswer(
+      session
+        .sql("SELECT 1")
+        .select(lit(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))),
+      Seq(Row(Duration.ofDays(2).plusHours(12).plusMinutes(30).plusSeconds(45))))
+    // Period: INTERVAL '...' YEAR TO MONTH round-trip; ofMonths(14) normalizes to 1-2
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Period.of(1, 6, 0))),
+      Seq(Row(Period.of(1, 6, 0))))
+    checkAnswer(
+      session.sql("SELECT 1").select(lit(Period.ofMonths(14))),
+      Seq(Row(Period.of(1, 2, 0))))
   }
 
   test("approx count distinct") {

--- a/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
@@ -9,7 +9,6 @@ import java.time.{Duration, Period}
  * End-to-end UDF tests for native INTERVAL types.
  *
  * Prerequisites:
- *   - Account/session parameter ENABLE_INTERVAL_TYPES_IN_UDF = TRUE
  *   - JDBC 3.27.0+ (typed Duration/Period ResultSet reads)
  *
  * Mirrors snowpark-python tests/integ/test_interval_udf_e2e.py
@@ -17,18 +16,8 @@ import java.time.{Duration, Period}
 @UDFTest
 class IntervalUDFSuite extends TestData {
 
-  private def withIntervalUdfEnabled(body: => Unit): Unit = {
-    // ACCOUNT_LINEAGE | XP_WORKER — not session-settable. Temptest often requires a
-    // parameter_comment on ALTER ACCOUNT, so we require the flag already enabled.
-    val rows =
-      session.sql("SHOW PARAMETERS LIKE 'ENABLE_INTERVAL_TYPES_IN_UDF' IN ACCOUNT").collect()
-    val enabled = rows.exists(r => Option(r.getString(1)).exists(_.equalsIgnoreCase("true")))
-    assert(
-      enabled,
-      "ENABLE_INTERVAL_TYPES_IN_UDF must be TRUE at account level " +
-        "(ALTER ACCOUNT SET ... with a valid parameter_comment on temptest)")
-    body
-  }
+  private def withIntervalUdfEnabled(body: => Unit): Unit =
+    withSessionParameters(Seq(("ENABLE_INTERVAL_TYPES_IN_UDF", "true")), session)(body)
 
   override def beforeAll: Unit = {
     super.beforeAll()

--- a/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
@@ -16,9 +16,6 @@ import java.time.{Duration, Period}
 @UDFTest
 class IntervalUDFSuite extends TestData {
 
-  private def withIntervalUdfEnabled(body: => Unit): Unit =
-    withSessionParameters(Seq(("ENABLE_INTERVAL_TYPES_IN_UDF", "true")), session)(body)
-
   override def beforeAll: Unit = {
     super.beforeAll()
     if (!isStoredProc(session)) {
@@ -27,67 +24,51 @@ class IntervalUDFSuite extends TestData {
   }
 
   test("UDF Duration input/return (INTERVAL DAY TO SECOND)", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val addDay = udf((x: Duration) => if (x == null) null else x.plusDays(1))
-      val df = session.sql("SELECT INTERVAL '5' DAY AS d")
-      checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
-    }
+    val addDay = udf((x: Duration) => if (x == null) null else x.plusDays(1))
+    val df = session.sql("SELECT INTERVAL '5' DAY AS d")
+    checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
   }
 
   test("UDF Duration with day-time components", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val triple = udf((x: Duration) => x.multipliedBy(3))
-      val df = session.sql("SELECT INTERVAL '2 12:00:00' DAY TO SECOND AS d")
-      checkAnswer(df.select(triple(col("d"))), Seq(Row(Duration.ofDays(7).plusHours(12))))
-    }
+    val triple = udf((x: Duration) => x.multipliedBy(3))
+    val df = session.sql("SELECT INTERVAL '2 12:00:00' DAY TO SECOND AS d")
+    checkAnswer(df.select(triple(col("d"))), Seq(Row(Duration.ofDays(7).plusHours(12))))
   }
 
   test("UDF Duration null input", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val identity = udf((x: Duration) => x)
-      val df = session.sql("SELECT NULL::INTERVAL DAY TO SECOND AS d")
-      checkAnswer(df.select(identity(col("d"))), Seq(Row(null)))
-    }
+    val identity = udf((x: Duration) => x)
+    val df = session.sql("SELECT NULL::INTERVAL DAY TO SECOND AS d")
+    checkAnswer(df.select(identity(col("d"))), Seq(Row(null)))
   }
 
   test("UDF Duration negative interval", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val negate = udf((x: Duration) => x.negated())
-      val df = session.sql("SELECT INTERVAL '3' DAY AS d")
-      checkAnswer(df.select(negate(col("d"))), Seq(Row(Duration.ofDays(-3))))
-    }
+    val negate = udf((x: Duration) => x.negated())
+    val df = session.sql("SELECT INTERVAL '3' DAY AS d")
+    checkAnswer(df.select(negate(col("d"))), Seq(Row(Duration.ofDays(-3))))
   }
 
   test("UDF Duration to Long (inspect components)", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val getDays = udf((x: Duration) => x.toDays)
-      val df = session.sql("SELECT INTERVAL '5 06:30:00' DAY TO SECOND AS d")
-      checkAnswer(df.select(getDays(col("d"))), Seq(Row(5L)))
-    }
+    val getDays = udf((x: Duration) => x.toDays)
+    val df = session.sql("SELECT INTERVAL '5 06:30:00' DAY TO SECOND AS d")
+    checkAnswer(df.select(getDays(col("d"))), Seq(Row(5L)))
   }
 
   test("UDF Period input/return (INTERVAL YEAR TO MONTH)", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val addYear = udf((x: Period) => if (x == null) null else x.plusYears(1))
-      val df = session.sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m")
-      // 1 year 2 months + 1 year = 2 years 2 months
-      checkAnswer(df.select(addYear(col("m"))), Seq(Row(Period.of(2, 2, 0))))
-    }
+    val addYear = udf((x: Period) => if (x == null) null else x.plusYears(1))
+    val df = session.sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m")
+    // 1 year 2 months + 1 year = 2 years 2 months
+    checkAnswer(df.select(addYear(col("m"))), Seq(Row(Period.of(2, 2, 0))))
   }
 
   test("UDF Period null input", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val identity = udf((x: Period) => x)
-      val df = session.sql("SELECT NULL::INTERVAL YEAR TO MONTH AS m")
-      checkAnswer(df.select(identity(col("m"))), Seq(Row(null)))
-    }
+    val identity = udf((x: Period) => x)
+    val df = session.sql("SELECT NULL::INTERVAL YEAR TO MONTH AS m")
+    checkAnswer(df.select(identity(col("m"))), Seq(Row(null)))
   }
 
   test("registerTemporary Duration UDF", JavaStoredProcExclude) {
-    withIntervalUdfEnabled {
-      val addDay = session.udf.registerTemporary((x: Duration) => x.plusDays(1))
-      val df = session.sql("SELECT INTERVAL '5' DAY AS d")
-      checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
-    }
+    val addDay = session.udf.registerTemporary((x: Duration) => x.plusDays(1))
+    val df = session.sql("SELECT INTERVAL '5' DAY AS d")
+    checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
   }
 }

--- a/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/IntervalUDFSuite.scala
@@ -1,0 +1,104 @@
+package com.snowflake.snowpark_test
+
+import com.snowflake.snowpark.functions._
+import com.snowflake.snowpark.{JavaStoredProcExclude, Row, TestData, TestUtils, UDFTest}
+
+import java.time.{Duration, Period}
+
+/**
+ * End-to-end UDF tests for native INTERVAL types.
+ *
+ * Prerequisites:
+ *   - Account/session parameter ENABLE_INTERVAL_TYPES_IN_UDF = TRUE
+ *   - JDBC 3.27.0+ (typed Duration/Period ResultSet reads)
+ *
+ * Mirrors snowpark-python tests/integ/test_interval_udf_e2e.py
+ */
+@UDFTest
+class IntervalUDFSuite extends TestData {
+
+  private def withIntervalUdfEnabled(body: => Unit): Unit = {
+    // ACCOUNT_LINEAGE | XP_WORKER — not session-settable. Temptest often requires a
+    // parameter_comment on ALTER ACCOUNT, so we require the flag already enabled.
+    val rows =
+      session.sql("SHOW PARAMETERS LIKE 'ENABLE_INTERVAL_TYPES_IN_UDF' IN ACCOUNT").collect()
+    val enabled = rows.exists(r => Option(r.getString(1)).exists(_.equalsIgnoreCase("true")))
+    assert(
+      enabled,
+      "ENABLE_INTERVAL_TYPES_IN_UDF must be TRUE at account level " +
+        "(ALTER ACCOUNT SET ... with a valid parameter_comment on temptest)")
+    body
+  }
+
+  override def beforeAll: Unit = {
+    super.beforeAll()
+    if (!isStoredProc(session)) {
+      TestUtils.addDepsToClassPath(session)
+    }
+  }
+
+  test("UDF Duration input/return (INTERVAL DAY TO SECOND)", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val addDay = udf((x: Duration) => if (x == null) null else x.plusDays(1))
+      val df = session.sql("SELECT INTERVAL '5' DAY AS d")
+      checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
+    }
+  }
+
+  test("UDF Duration with day-time components", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val triple = udf((x: Duration) => x.multipliedBy(3))
+      val df = session.sql("SELECT INTERVAL '2 12:00:00' DAY TO SECOND AS d")
+      checkAnswer(df.select(triple(col("d"))), Seq(Row(Duration.ofDays(7).plusHours(12))))
+    }
+  }
+
+  test("UDF Duration null input", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val identity = udf((x: Duration) => x)
+      val df = session.sql("SELECT NULL::INTERVAL DAY TO SECOND AS d")
+      checkAnswer(df.select(identity(col("d"))), Seq(Row(null)))
+    }
+  }
+
+  test("UDF Duration negative interval", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val negate = udf((x: Duration) => x.negated())
+      val df = session.sql("SELECT INTERVAL '3' DAY AS d")
+      checkAnswer(df.select(negate(col("d"))), Seq(Row(Duration.ofDays(-3))))
+    }
+  }
+
+  test("UDF Duration to Long (inspect components)", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val getDays = udf((x: Duration) => x.toDays)
+      val df = session.sql("SELECT INTERVAL '5 06:30:00' DAY TO SECOND AS d")
+      checkAnswer(df.select(getDays(col("d"))), Seq(Row(5L)))
+    }
+  }
+
+  test("UDF Period input/return (INTERVAL YEAR TO MONTH)", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val addYear = udf((x: Period) => if (x == null) null else x.plusYears(1))
+      val df = session.sql("SELECT INTERVAL '1-2' YEAR TO MONTH AS m")
+      // 1 year 2 months + 1 year = 2 years 2 months
+      checkAnswer(df.select(addYear(col("m"))), Seq(Row(Period.of(2, 2, 0))))
+    }
+  }
+
+  test("UDF Period null input", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val identity = udf((x: Period) => x)
+      val df = session.sql("SELECT NULL::INTERVAL YEAR TO MONTH AS m")
+      checkAnswer(df.select(identity(col("m"))), Seq(Row(null)))
+    }
+  }
+
+  test("registerTemporary Duration UDF", JavaStoredProcExclude) {
+    withIntervalUdfEnabled {
+      val addDay = session.udf.registerTemporary((x: Duration) => x.plusDays(1))
+      val df = session.sql("SELECT INTERVAL '5' DAY AS d")
+      checkAnswer(df.select(addDay(col("d"))), Seq(Row(Duration.ofDays(6))))
+    }
+  }
+}

--- a/src/test/scala/com/snowflake/snowpark_test/RowSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/RowSuite.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark.types._
 import com.snowflake.snowpark.{Row, SNTestBase, SnowparkClientException}
 
 import java.sql.{Date, Time, Timestamp}
-import java.time.{Instant, LocalDate}
+import java.time.{Duration, Instant, LocalDate, Period}
 import java.util
 
 class RowSuite extends SNTestBase {
@@ -383,6 +383,22 @@ class RowSuite extends SNTestBase {
         val array4 = row.getAs[Array[Object]](3)
         assert(array4 sameElements Array("[\n  1,\n  2\n]"))
       }
+    }
+  }
+
+  test("getAs with structured interval fields") {
+    structuredTypeTest {
+      val query =
+        """SELECT
+          |  [INTERVAL '5' DAY]::ARRAY(INTERVAL DAY TO SECOND) AS arr,
+          |  {'m': INTERVAL '1-2' YEAR TO MONTH}::MAP(VARCHAR, INTERVAL YEAR TO MONTH) AS mp
+          |""".stripMargin
+      val df = session.sql(query)
+      val row = df.collect()(0)
+      val arr = row.getAs[Array[Object]](0)
+      assert(arr(0) == Duration.ofDays(5))
+      val mp = row.getAs[Map[String, Object]](1)
+      assert(mp("m") == Period.of(1, 2, 0))
     }
   }
 

--- a/src/test/scala/com/snowflake/snowpark_test/RowSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/RowSuite.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark.types._
 import com.snowflake.snowpark.{Row, SNTestBase, SnowparkClientException}
 
 import java.sql.{Date, Time, Timestamp}
-import java.time.{Duration, Instant, LocalDate, Period}
+import java.time.{Instant, LocalDate}
 import java.util
 
 class RowSuite extends SNTestBase {
@@ -383,22 +383,6 @@ class RowSuite extends SNTestBase {
         val array4 = row.getAs[Array[Object]](3)
         assert(array4 sameElements Array("[\n  1,\n  2\n]"))
       }
-    }
-  }
-
-  test("getAs with structured interval fields") {
-    structuredTypeTest {
-      val query =
-        """SELECT
-          |  [INTERVAL '5' DAY]::ARRAY(INTERVAL DAY TO SECOND) AS arr,
-          |  {'m': INTERVAL '1-2' YEAR TO MONTH}::MAP(VARCHAR, INTERVAL YEAR TO MONTH) AS mp
-          |""".stripMargin
-      val df = session.sql(query)
-      val row = df.collect()(0)
-      val arr = row.getAs[Array[Object]](0)
-      assert(arr(0) == Duration.ofDays(5))
-      val mp = row.getAs[Map[String, Object]](1)
-      assert(mp("m") == Period.of(1, 2, 0))
     }
   }
 


### PR DESCRIPTION
1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or issue accompanying your PR.

   Fixes SNOW-3746508 

2. Fill out the following pre-review checklist:

   - [x] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

3. Please describe how your code solves the related issue.

Adds `DayTimeIntervalType` and `YearMonthIntervalType` as first-class types in the Snowpark Java/Scala SDK, enabling them to be declared as UDF and stored procedure parameter and return types.

**Type system additions:**
- `DayTimeIntervalType` / `YearMonthIntervalType` in both the Scala and Java type APIs
- At the UDF/sproc boundary, `INTERVAL DAY TO SECOND` values are transmitted as Arrow `MonthDayNano` and surfaced to handlers as `java.time.Duration`; `INTERVAL YEAR TO MONTH` values are surfaced as `java.time.Period`

**DataFrame API additions:**
- `lit(Duration)` / `lit(Period)` — construct interval literal columns in DataFrame expressions
- `createDataFrame(data, schema)` with interval schema columns — `Duration`/`Period` values are serialized to Snowflake interval string format and CAST back on read

**Result reading:**
- `Row.getDuration()` / `Row.getPeriod()` for typed interval result extraction (requires JDBC 3.27+; `build.sbt` bumped to `3.27.1`)

**Tests:**
- Unit tests covering type parsing, type attribute properties, and Java↔Scala type bridge roundtrips
- E2E integration tests for `lit(Duration|Period)` and `createDataFrame` with interval schema — Scala (`FunctionSuite`, `DataFrameSuite`) and Java (`JavaFunctionSuite`, `JavaDataFrameSuite`); verified passing without any feature flags
- E2E UDF integration tests (`IntervalUDFSuite`, `JavaUDFSuite`) requiring `ENABLE_INTERVAL_TYPES_IN_UDF`; the flag is set at session level via `ALTER SESSION SET` before each test and unset after, so tests run automatically once the parameter is available in the environment