### PR TITLE
Bump snowflake-jdbc to 4.3.2 and migrate to the 4.x namespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val javadocSettings = inConfig(Javadoc)(Defaults.configSettings) ++ Seq(
   Javadoc / packageDoc / artifactName := ((sv, mod, art) =>
     "" + mod.name + "_" + sv.binary + "-" + mod.revision + "-javadoc.jar"))
 
-val jdbcVersion = "3.24.2"
+val jdbcVersion = "4.3.2"
 val jacksonVersion = "2.18.0"
 val openTelemetryVersion = "1.39.0"
 val slf4jVersion = "2.0.16"

--- a/src/main/java/com/snowflake/snowpark/internal/Logging.java
+++ b/src/main/java/com/snowflake/snowpark/internal/Logging.java
@@ -2,7 +2,7 @@ package com.snowflake.snowpark.internal;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import net.snowflake.client.util.SecretDetector;
+import net.snowflake.client.internal.util.SecretDetector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/scala/com/snowflake/snowpark/Session.scala
+++ b/src/main/scala/com/snowflake/snowpark/Session.scala
@@ -21,7 +21,9 @@ import com.snowflake.snowpark.internal.Utils.{
   getTableFunctionExpression,
   randomNameForTempObject
 }
-import net.snowflake.client.jdbc.{SnowflakeConnectionV1, SnowflakeDriver, SnowflakeSQLException}
+import net.snowflake.client.api.driver.SnowflakeDriver
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
@@ -86,7 +88,7 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
        | "scala.version" : "${Utils.ScalaVersion}",
        | "jdbc.session.id" : "$sessionId",
        | "os.name" : "${Utils.OSName}",
-       | "jdbc.version" : "${SnowflakeDriver.implementVersion}",
+       | "jdbc.version" : "${SnowflakeDriver.getImplementationVersion}",
        | "snowpark.library" : "${Utils.escapePath(
         UDFClassPath.snowparkJar.location.getOrElse("snowpark library not found"))}",
        | "scala.library" : "${Utils.escapePath(
@@ -95,7 +97,7 @@ class Session private (private[snowpark] val conn: ServerConnection) extends Log
           .getOrElse("Scala library not found"))}",
        | "jdbc.library" : "${Utils.escapePath(
         UDFClassPath
-          .getPathForClass(classOf[net.snowflake.client.jdbc.SnowflakeDriver])
+          .getPathForClass(classOf[SnowflakeDriver])
           .getOrElse("JDBC library not found"))}"
        |}""".stripMargin
 
@@ -1477,7 +1479,7 @@ object Session extends Logging {
    * @return
    *   [[Session]]
    */
-  private[snowpark] def apply(connection: SnowflakeConnectionV1): Session = {
+  private[snowpark] def apply(connection: SnowflakeConnectionImpl): Session = {
     Session.builder.createInternal(Some(connection))
   }
 
@@ -1692,7 +1694,7 @@ object Session extends Logging {
       Session.getActiveSession.getOrElse(create)
     }
 
-    private[snowpark] def createInternal(conn: Option[SnowflakeConnectionV1]): Session = {
+    private[snowpark] def createInternal(conn: Option[SnowflakeConnectionImpl]): Session = {
       conn match {
         case Some(_) =>
           setActiveSession(new Session(new ServerConnection(Map.empty, isScalaAPI, conn)))

--- a/src/main/scala/com/snowflake/snowpark/internal/ParameterUtils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ParameterUtils.scala
@@ -1,6 +1,6 @@
 package com.snowflake.snowpark.internal
 
-import net.snowflake.client.core.SFSessionProperty
+import net.snowflake.client.internal.core.SFSessionProperty
 
 import java.security.spec.{PKCS8EncodedKeySpec, RSAPrivateCrtKeySpec}
 import java.security.{GeneralSecurityException, KeyFactory, PrivateKey}

--- a/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/ServerConnection.scala
@@ -25,25 +25,30 @@ import com.snowflake.snowpark.internal.ParameterUtils.{
 }
 import com.snowflake.snowpark.internal.Utils.PackageNameDelimiter
 import com.snowflake.snowpark.internal.analyzer.{Attribute, Query, SnowflakePlan}
-import net.snowflake.client.jdbc.{
+import net.snowflake.client.api.connection.{DownloadStreamConfig, UploadStreamConfig}
+import net.snowflake.client.api.resultset.{
   FieldMetadata,
-  SnowflakeBaseResultSet,
-  SnowflakeConnectString,
-  SnowflakeConnectionV1,
-  SnowflakePreparedStatement,
-  SnowflakeReauthenticationRequest,
+  QueryStatus,
   SnowflakeResultSet,
-  SnowflakeResultSetMetaData,
+  SnowflakeResultSetMetaData
+}
+import net.snowflake.client.api.statement.{SnowflakePreparedStatement, SnowflakeStatement}
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
+import net.snowflake.client.internal.api.implementation.resultset.{
+  FieldMetadataImpl,
+  SnowflakeBaseResultSet
+}
+import net.snowflake.client.internal.jdbc.{
+  SnowflakeConnectString,
+  SnowflakeReauthenticationRequest,
   SnowflakeResultSetV1,
-  SnowflakeStatement,
   SnowflakeUtil
 }
 import com.snowflake.snowpark.types._
-import net.snowflake.client.core.arrow.StructObjectWrapper
-import net.snowflake.client.core.{
+import net.snowflake.client.internal.core.arrow.StructObjectWrapper
+import net.snowflake.client.internal.core.{
   ArrowSqlInput,
   ColumnTypeHelper,
-  QueryStatus,
   SFArrowResultSet,
   SFBaseResultSet
 }
@@ -220,7 +225,7 @@ private[snowpark] object ServerConnection {
 private[snowpark] class ServerConnection(
     options: Map[String, String],
     val isScalaAPI: Boolean,
-    private val jdbcConn: Option[SnowflakeConnectionV1])
+    private val jdbcConn: Option[SnowflakeConnectionImpl])
     extends Logging {
 
   val isStoredProc = jdbcConn.isDefined
@@ -231,7 +236,7 @@ private[snowpark] class ServerConnection(
     // scalastyle:on
   }
 
-  val connection: SnowflakeConnectionV1 = jdbcConn.getOrElse {
+  val connection: SnowflakeConnectionImpl = jdbcConn.getOrElse {
     val connURL = ServerConnection.connectionString(lowerCaseParameters)
     val connParam = ParameterUtils.jdbcConfig(lowerCaseParameters, isScalaAPI)
     val connStr = SnowflakeConnectString.parse(connURL, connParam)
@@ -239,7 +244,7 @@ private[snowpark] class ServerConnection(
       throw ErrorMessage.MISC_INVALID_CONNECTION_STRING(s"$connStr")
     }
     // Identify the client type as Snowpark instead of JDBC.
-    new SnowflakeConnectionV1(new SnowparkSFConnectionHandler(connStr), connURL, connParam)
+    new SnowflakeConnectionImpl(new SnowparkSFConnectionHandler(connStr), connURL, connParam)
   }
 
   private[snowpark] def close(): Unit =
@@ -430,12 +435,20 @@ private[snowpark] class ServerConnection(
       inputStream: InputStream,
       destFileName: String,
       compressData: Boolean): Unit = withValidConnection {
-    connection.uploadStream(stageName, destPrefix, inputStream, destFileName, compressData)
+    // Since JDBC 4.0.0 the destination prefix and compression flag are passed via a config object,
+    // and the second positional argument is the destination file name rather than the prefix.
+    val config = UploadStreamConfig
+      .builder()
+      .setDestPrefix(destPrefix)
+      .setCompressData(compressData)
+      .build()
+    connection.uploadStream(stageName, destFileName, inputStream, config)
   }
 
   def downloadStream(stageName: String, sourceFileName: String, decompress: Boolean): InputStream =
     withValidConnection {
-      connection.downloadStream(stageName, sourceFileName, decompress)
+      val config = DownloadStreamConfig.builder().setDecompress(decompress).build()
+      connection.downloadStream(stageName, sourceFileName, config)
     }
 
   // Run the query and return the queryID when the caller doesn't need the ResultSet
@@ -902,7 +915,7 @@ private[snowpark] class ServerConnection(
     }
 
   private[snowpark] def isDone(queryID: String): Boolean =
-    !QueryStatus.isStillRunning(connection.getSFBaseSession.getQueryStatus(queryID))
+    !connection.getSFBaseSession.getQueryStatus(queryID).isStillRunning
 
   private[snowpark] def waitForQueryDone(
       queryID: String,
@@ -918,7 +931,7 @@ private[snowpark] class ServerConnection(
     var retry = 0
     var lastLogTime = 0
     var totalWaitTime = 0
-    while (QueryStatus.isStillRunning(qs) &&
+    while (qs.isStillRunning &&
       totalWaitTime + getSeepTime(retry + 1) < maxWaitTimeInSeconds * 1000) {
       Thread.sleep(getSeepTime(retry))
       totalWaitTime = totalWaitTime + getSeepTime(retry)
@@ -927,12 +940,13 @@ private[snowpark] class ServerConnection(
       if (totalWaitTime - lastLogTime > 60 * 1000 || lastLogTime == 0) {
         logWarning(
           s"Checking the query status for $queryID at ${LocalDateTime.now()}," +
-            s" the current status is $qs.")
+            s" the current status is ${qs.getStatus}.")
         lastLogTime = totalWaitTime
       }
     }
-    if (QueryStatus.isStillRunning(qs)) {
-      throw ErrorMessage.PLAN_QUERY_IS_STILL_RUNNING(queryID, qs.toString, totalWaitTime / 1000)
+    if (qs.isStillRunning) {
+      throw ErrorMessage
+        .PLAN_QUERY_IS_STILL_RUNNING(queryID, qs.getStatus.toString, totalWaitTime / 1000)
     }
     qs
   }
@@ -1069,7 +1083,7 @@ private[snowflake] class SnowflakeResultSetExt(data: SnowflakeResultSetV1) {
   def getObject(index: Int): Any = {
     val meta = data.getMetaData
     // convert meta to field meta
-    val field = new FieldMetadata(
+    val field = new FieldMetadataImpl(
       meta.getColumnName(index),
       meta.getColumnTypeName(index),
       meta.getColumnType(index),

--- a/src/main/scala/com/snowflake/snowpark/internal/SnowparkSFConnectionHandler.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/SnowparkSFConnectionHandler.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark.internal
 
 import com.snowflake.snowpark.internal.SnowparkSFConnectionHandler.extractValidVersionNumber
 import net.snowflake.client.jdbc.internal.snowflake.common.core.LoginInfoDTO
-import net.snowflake.client.jdbc.{DefaultSFConnectionHandler, SnowflakeConnectString}
+import net.snowflake.client.internal.jdbc.{DefaultSFConnectionHandler, SnowflakeConnectString}
 
 import java.util.Properties
 

--- a/src/main/scala/com/snowflake/snowpark/internal/Telemetry.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Telemetry.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark.internal
 
 import com.snowflake.snowpark.SnowparkClientException
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
-import net.snowflake.client.jdbc.telemetry.TelemetryUtil
+import net.snowflake.client.internal.jdbc.telemetry.TelemetryUtil
 import Telemetry._
 
 final class Telemetry(conn: ServerConnection) extends Logging {

--- a/src/main/scala/com/snowflake/snowpark/internal/UDXRegistrationHandler.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/UDXRegistrationHandler.scala
@@ -19,7 +19,7 @@ import com.snowflake.snowpark_java.types.{StructType => JavaStructType}
 import com.snowflake.snowpark_java.udtf._
 import com.snowflake.snowpark_java.udaf._
 import com.snowflake.snowpark_java.sproc._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/Utils.scala
@@ -16,7 +16,7 @@ import java.security.{DigestInputStream, MessageDigest}
 import java.util.Locale
 import java.util.regex.Pattern
 import com.snowflake.snowpark.udtf.UDTF
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.JavaConverters.{asScalaIteratorConverter, mapAsScalaMapConverter}
 import scala.collection.mutable

--- a/src/main/scala/com/snowflake/snowpark/internal/analyzer/SnowflakePlan.scala
+++ b/src/main/scala/com/snowflake/snowpark/internal/analyzer/SnowflakePlan.scala
@@ -18,7 +18,7 @@ import com.snowflake.snowpark.internal.Utils.{
   randomNameForTempObject
 }
 import com.snowflake.snowpark.types.StructType
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.immutable.HashSet
 import scala.collection.mutable

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataFrameNonStoredProcSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataFrameNonStoredProcSuite.java
@@ -1,7 +1,7 @@
 package com.snowflake.snowpark_test;
 
 import com.snowflake.snowpark_java.*;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 public class JavaDataFrameNonStoredProcSuite extends TestBase {

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataFrameSuite.java
@@ -6,7 +6,7 @@ import com.snowflake.snowpark_java.*;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 public class JavaDataFrameSuite extends TestBase {

--- a/src/test/java/com/snowflake/snowpark_test/JavaDataFrameWriterSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaDataFrameWriterSuite.java
@@ -10,7 +10,7 @@ import com.snowflake.snowpark_java.types.StructField;
 import com.snowflake.snowpark_java.types.StructType;
 import java.util.HashMap;
 import java.util.Map;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 public class JavaDataFrameWriterSuite extends TestBase {

--- a/src/test/java/com/snowflake/snowpark_test/JavaFileOperationSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFileOperationSuite.java
@@ -15,7 +15,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 public class JavaFileOperationSuite extends TestBase {

--- a/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaFunctionSuite.java
@@ -10,7 +10,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionNonStoredProcSuite.java
@@ -11,7 +11,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 // This suite includes test case which can't be run in java stored proc

--- a/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaSessionSuite.java
@@ -7,7 +7,7 @@ import com.snowflake.snowpark_java.types.DataTypes;
 import com.snowflake.snowpark_java.types.StructField;
 import com.snowflake.snowpark_java.types.StructType;
 import java.sql.Connection;
-import net.snowflake.client.jdbc.SnowflakeConnection;
+import net.snowflake.client.api.connection.SnowflakeConnection;
 import org.junit.Test;
 
 public class JavaSessionSuite extends TestBase {

--- a/src/test/java/com/snowflake/snowpark_test/JavaUDFNonStoredProcSuite.java
+++ b/src/test/java/com/snowflake/snowpark_test/JavaUDFNonStoredProcSuite.java
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test;
 
 import com.snowflake.snowpark_java.*;
 import com.snowflake.snowpark_java.types.*;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.api.exception.SnowflakeSQLException;
 import org.junit.Test;
 
 // This suite includes test case which can't be run in java stored proc

--- a/src/test/scala/com/snowflake/snowpark/APIInternalSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/APIInternalSuite.scala
@@ -15,8 +15,8 @@ import com.snowflake.snowpark.internal.analyzer.{
   schemaValueStatement
 }
 import com.snowflake.snowpark.types._
-import net.snowflake.client.core.SFSessionProperty
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.internal.core.SFSessionProperty
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}

--- a/src/test/scala/com/snowflake/snowpark/ParameterSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/ParameterSuite.scala
@@ -1,7 +1,7 @@
 package com.snowflake.snowpark
 
 import com.snowflake.snowpark.internal.{ParameterUtils, ServerConnection}
-import net.snowflake.client.core.SFSessionProperty
+import net.snowflake.client.internal.core.SFSessionProperty
 
 import java.security.KeyPairGenerator
 import java.security.spec.PKCS8EncodedKeySpec

--- a/src/test/scala/com/snowflake/snowpark/ServerConnectionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/ServerConnectionSuite.scala
@@ -2,8 +2,9 @@ package com.snowflake.snowpark
 
 import com.snowflake.snowpark.internal.analyzer._
 import com.snowflake.snowpark.types._
-import net.snowflake.client.core.QueryStatus
-import net.snowflake.client.jdbc.{SnowflakeResultSet, SnowflakeSQLException, SnowflakeStatement}
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import net.snowflake.client.api.resultset.SnowflakeResultSet
+import net.snowflake.client.api.statement.SnowflakeStatement
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -37,7 +38,8 @@ class ServerConnectionSuite extends SNTestBase {
         .executeAsyncQuery("select SYSTEM$WAIT(2)")
         .asInstanceOf[SnowflakeResultSet]
         .getQueryID
-      assert(session.conn.waitForQueryDone(queryID, 100).equals(QueryStatus.SUCCESS))
+      // Since JDBC 4.0.0 QueryStatus is a value object rather than an enum constant.
+      assert(session.conn.waitForQueryDone(queryID, 100).isSuccess)
 
       // Negative tests
       queryID = statement

--- a/src/test/scala/com/snowflake/snowpark/SnowflakePlanSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/SnowflakePlanSuite.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark.internal.analyzer._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.internal.Utils
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/src/test/scala/com/snowflake/snowpark/TestUtils.scala
+++ b/src/test/scala/com/snowflake/snowpark/TestUtils.scala
@@ -23,11 +23,8 @@ import java.util.{Locale, Properties}
 import com.snowflake.snowpark.Session.loadConfFromFile
 import com.snowflake.snowpark.internal.ParameterUtils.ClosureCleanerMode
 import com.snowflake.snowpark.internal.Utils.TempObjectType
-import net.snowflake.client.jdbc.{
-  DefaultSFConnectionHandler,
-  SnowflakeConnectString,
-  SnowflakeConnectionV1
-}
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
+import net.snowflake.client.internal.jdbc.{DefaultSFConnectionHandler, SnowflakeConnectString}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.security.Provider
@@ -362,7 +359,7 @@ object TestUtils extends Logging {
     }
   }
 
-  private[snowpark] def createJDBCConnection(propertyFile: String): SnowflakeConnectionV1 = {
+  private[snowpark] def createJDBCConnection(propertyFile: String): SnowflakeConnectionImpl = {
     val options = loadConfFromFile(propertyFile).map { case (key, value) =>
       key.toLowerCase(Locale.ENGLISH) -> value
     }
@@ -370,7 +367,7 @@ object TestUtils extends Logging {
     val connURL = ServerConnection.connectionString(options)
     val connParam = ParameterUtils.jdbcConfig(options, isScalaAPI = true)
     val connStr = SnowflakeConnectString.parse(connURL, connParam)
-    new SnowflakeConnectionV1(new DefaultSFConnectionHandler(connStr), connURL, connParam)
+    new SnowflakeConnectionImpl(new DefaultSFConnectionHandler(connStr), connURL, connParam)
   }
 
   // Snowflake JDBC FIPS requires client manually load bouncy-castle fips provider

--- a/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark/UtilsSuite.scala
@@ -23,7 +23,7 @@ import java.lang.{
   Long => JavaLong,
   Short => JavaShort
 }
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.util
 import scala.collection.mutable.ArrayBuffer
@@ -584,12 +584,16 @@ class UtilsSuite extends SNTestBase {
 
   test("Utils.isRetryable") {
     // positive test
-    assert(Utils.isRetryable(new SnowflakeSQLException("JDBC driver internal error", "state_1")))
-    assert(Utils.isRetryable(new SnowflakeSQLException("JDBC driver internal error", "state_2")))
+    assert(
+      Utils.isRetryable(
+        new SnowflakeSQLException(null: String, "JDBC driver internal error", "state_1")))
+    assert(
+      Utils.isRetryable(
+        new SnowflakeSQLException(null: String, "JDBC driver internal error", "state_2")))
     // negative test
     assert(!Utils.isRetryable(new Exception("test error")))
     assert(!Utils.isRetryable(new Exception("JDBC driver internal error")))
-    assert(!Utils.isRetryable(new SnowflakeSQLException("test error", "state_1")))
+    assert(!Utils.isRetryable(new SnowflakeSQLException(null: String, "test error", "state_1")))
   }
 
   test("Utils.withRetry") {
@@ -600,7 +604,7 @@ class UtilsSuite extends SNTestBase {
     Utils.withRetry(3, "test_A") {
       result.append(1)
       if (result.size < 2) {
-        throw new SnowflakeSQLException("JDBC driver internal error", "state_1")
+        throw new SnowflakeSQLException(null: String, "JDBC driver internal error", "state_1")
       }
     }
     assert(result.size == 2)
@@ -610,7 +614,7 @@ class UtilsSuite extends SNTestBase {
     Utils.withRetry(4, "test_A") {
       result.append(1)
       if (result.size < 3) {
-        throw new SnowflakeSQLException("JDBC driver internal error", "state_1")
+        throw new SnowflakeSQLException(null: String, "JDBC driver internal error", "state_1")
       }
     }
     assert(result.size == 3)
@@ -620,7 +624,7 @@ class UtilsSuite extends SNTestBase {
     var ex = intercept[SnowflakeSQLException] {
       Utils.withRetry(3, "test_A") {
         result.append(1)
-        throw new SnowflakeSQLException("JDBC driver internal error", "state_1")
+        throw new SnowflakeSQLException(null: String, "JDBC driver internal error", "state_1")
       }
     }
     assert(ex.getMessage.contains("JDBC driver internal error"))
@@ -631,7 +635,7 @@ class UtilsSuite extends SNTestBase {
     ex = intercept[SnowflakeSQLException] {
       Utils.withRetry(3, "test_A") {
         result.append(1)
-        throw new SnowflakeSQLException("User error", "state_1")
+        throw new SnowflakeSQLException(null: String, "User error", "state_1")
       }
     }
     assert(ex.getMessage.contains("User error"))

--- a/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/AsyncJobSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import org.scalatest.{BeforeAndAfterEach, Tag}
 
 import scala.concurrent.Future

--- a/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/ColumnSuite.scala
@@ -7,7 +7,7 @@ import java.util.TimeZone
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random

--- a/src/test/scala/com/snowflake/snowpark_test/CopyableDataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/CopyableDataFrameSuite.scala
@@ -5,7 +5,7 @@ import java.util.Locale
 import com.snowflake.snowpark._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark.functions._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 class CopyableDataFrameSuite extends SNTestBase {
   val tmpStageName: String = randomStageName()

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameAggregateSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameAggregateSuite.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test
 
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.ResultSet
 

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameReaderSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameReaderSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import org.scalatest.Tag
 
 import scala.util.Random

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSetOperationsSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSetOperationsSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types.IntegerType
 import com.snowflake.snowpark.{Column, Row, SnowparkClientException, TestData}
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.{Date, Timestamp}
 

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameSuite.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark._
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.internal.analyzer._
 import com.snowflake.snowpark.types._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import org.scalatest.BeforeAndAfterEach
 import java.sql.{Date, Time, Timestamp}
 import scala.util.Random

--- a/src/test/scala/com/snowflake/snowpark_test/DataFrameWriterSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/DataFrameWriterSuite.scala
@@ -4,7 +4,7 @@ import com.snowflake.snowpark._
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.internal.analyzer.quoteName
 import com.snowflake.snowpark.types._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.{Date, Time}
 import scala.util.Random

--- a/src/test/scala/com/snowflake/snowpark_test/FileOperationSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FileOperationSuite.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test
 
 import com.snowflake.snowpark.TestUtils._
 import com.snowflake.snowpark.{SNTestBase, SnowparkClientException, TestUtils}
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import org.apache.commons.io._
 
 import java.io._

--- a/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/FunctionSuite.scala
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.snowflake.snowpark._
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.{Date, Time, Timestamp}
 

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDFSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.TestUtils.{removeFile, writeFile}
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 import java.io.FileOutputStream
 import java.math.RoundingMode
 import java.nio.file.{Files, Paths}

--- a/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/PermanentUDTFSuite.scala
@@ -5,7 +5,7 @@ import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark.udtf._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.collection.mutable
 

--- a/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SessionSuite.scala
@@ -4,7 +4,9 @@ import com.snowflake.snowpark.internal.analyzer.quoteName
 import com.snowflake.snowpark.internal.{SnowparkSFConnectionHandler, Utils}
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.{SnowflakeConnectionV1, SnowflakeDriver, SnowflakeSQLException}
+import net.snowflake.client.api.driver.SnowflakeDriver
+import net.snowflake.client.api.exception.SnowflakeSQLException
+import net.snowflake.client.internal.api.implementation.connection.SnowflakeConnectionImpl
 import com.snowflake.snowpark.functions._
 import java.io.File
 
@@ -362,9 +364,10 @@ class SessionSuite extends SNTestBase {
       jsonSessionInfo
         .get("jdbc.session.id")
         .asText()
-        .equals(session.jdbcConnection.asInstanceOf[SnowflakeConnectionV1].getSessionID))
+        .equals(session.jdbcConnection.asInstanceOf[SnowflakeConnectionImpl].getSessionID))
     assert(jsonSessionInfo.get("os.name").asText().equals(Utils.OSName))
-    assert(jsonSessionInfo.get("jdbc.version").asText().equals(SnowflakeDriver.implementVersion))
+    assert(
+      jsonSessionInfo.get("jdbc.version").asText().equals(SnowflakeDriver.getImplementationVersion))
     assert(jsonSessionInfo.get("snowpark.library").asText().nonEmpty)
     assert(jsonSessionInfo.get("scala.library").asText().nonEmpty)
     assert(jsonSessionInfo.get("jdbc.library").asText().nonEmpty)

--- a/src/test/scala/com/snowflake/snowpark_test/SqlSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/SqlSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.io.File
 import scala.reflect.io.Directory

--- a/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/StoredProcedureSuite.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test
 
 import com.snowflake.snowpark._
 import com.snowflake.snowpark.internal.Utils.{ScalaCompatVersion, SnowparkPackageName}
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.{Date, Timestamp}
 

--- a/src/test/scala/com/snowflake/snowpark_test/TableSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/TableSuite.scala
@@ -3,7 +3,7 @@ package com.snowflake.snowpark_test
 import com.snowflake.snowpark.functions.col
 import com.snowflake.snowpark.types._
 import com.snowflake.snowpark._
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import java.sql.Time
 import java.util.Locale

--- a/src/test/scala/com/snowflake/snowpark_test/WindowFramesSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/WindowFramesSuite.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test
 
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.{Row, SnowparkClientException, TestData, Window}
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 class WindowFramesSuite extends TestData {
   import session.implicits._

--- a/src/test/scala/com/snowflake/snowpark_test/WindowSpecSuite.scala
+++ b/src/test/scala/com/snowflake/snowpark_test/WindowSpecSuite.scala
@@ -2,7 +2,7 @@ package com.snowflake.snowpark_test
 
 import com.snowflake.snowpark.functions._
 import com.snowflake.snowpark.{DataFrame, Row, TestData, Window}
-import net.snowflake.client.jdbc.SnowflakeSQLException
+import net.snowflake.client.api.exception.SnowflakeSQLException
 
 import scala.reflect.ClassTag
 


### PR DESCRIPTION
# Bump snowflake-jdbc to 4.3.2 and migrate to the 4.x namespace

1. What Jira ticket or GitHub issue is this PR addressing? Make sure that there is a ticket or
   issue accompanying your PR.

   Fixes #282

2. Fill out the following pre-review checklist:

   - [ ] I am adding a new automated test(s) to verify correctness of my new code
   - [ ] I am adding new logging messages
   - [ ] I am adding a new telemetry message
   - [ ] I am adding new credentials
   - [ ] I am adding a new dependency

   No new tests or dependencies: existing tests are migrated to the new JDBC namespace, and the
   existing `snowflake-jdbc` pin moves `3.24.2` → `4.3.2` (a major-version jump).

3. Please describe how your code solves the related issue.

   Bumps `jdbcVersion` to `4.3.2` and migrates all JDBC references to the 4.x namespace, giving
   consumers the OAuth empty-scope fix (snowflakedb/snowflake-jdbc#2647) requested in #282.

---

## Why 4.x is unavoidable

| Fact | Consequence |
| --- | --- |
| The OAuth fix shipped in JDBC **4.3.0** (Jun 08, 2026) | We need ≥ 4.3.0 |
| It was **never backported to 3.x** — `3.28.0`, the last 3.x, does not have it | No 3.x option exists |
| The package restructure landed in **4.0.0** (Jan 27, 2026) | Any release with the fix also has the restructure |
| Latest Snowpark on Maven Central is **1.20.0**, pinned to `3.24.2` | No released Snowpark works with 4.x |

Overriding the driver version under a stock Snowpark release fails at runtime with
`NoClassDefFoundError`, so Snowpark itself must compile against 4.x — which is this PR. Bonus:
bundled Netty moves `4.1.118` → `4.1.136.Final`, **covering four CVE fixes per the JDBC release
notes.**

## What changed

Mostly import rewrites to the new `api.*` / `internal.*` split. Three real API changes:

1. **`uploadStream`**: the second positional `String` changed meaning (prefix → filename);
   prefix and compression now go into `UploadStreamConfig`. Mapped explicitly in
   `ServerConnection` — a naive migration compiles cleanly but uploads to the wrong path.
   `downloadStream` similarly takes a config object.
2. **`QueryStatus`** became a value object with no `toString` override; error `0318` and the
   wait-loop log now use `getStatus` to preserve the old `RUNNING`-style output.
3. `SnowflakeDriver.implementVersion` → `getImplementationVersion()`, and
   `SnowflakeSQLException(reason, sqlState)` → `(queryId, reason, sqlState)`.

## Consumer impact

Snowpark's public API is unchanged — no JDBC type appears in any public signature, and the Java
API has zero JDBC references. Consumers are only affected if they reach past Snowpark into JDBC
directly (e.g. catching `SnowflakeSQLException` by type — import-only fix; catching
`SQLException` still works). The real risk: a consumer pinning their own 3.x driver used to be
harmless, but now fails at runtime with `NoClassDefFoundError` while the build stays green —
release notes should state the required minimum driver version.

## Testing

`compile` + `Test/compile` pass on Scala 2.12.20 and 2.13.16, also with `SNOWPARK_FIPS=true`;
`CodeVerificationTests` 61/61. **I cannot run the integration suites** (no suitable account) —
please run them, especially OAuth/connection setup, structured-type reads, and
`FileOperationSuite` (given the `uploadStream` reorder).

## Risk to confirm

`Session.apply` — the stored-procedure entry point, public in bytecode — changed its parameter
type from `SnowflakeConnectionV1` to `SnowflakeConnectionImpl`. If the server-side sproc runtime
binds to the old signature it will hit `NoSuchMethodError`; this needs a check by someone with
visibility into that binding.